### PR TITLE
perf: mobile scroll budget + full certifications sync

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -10,22 +10,19 @@
 
     <AvailabilityBanner />
 
-    <!-- Global Scroll Progress -->
+    <!-- Global Scroll Progress — scale driven by --page-progress (direct DOM from useSmoothedScroll) -->
     <div
-      class="fixed left-0 right-0 h-1 z-110 origin-left bg-linear-to-r from-primary via-primary/80 to-primary/40 will-change-transform"
-      :style="{
-        top: 'var(--availability-banner-h, 0px)',
-        transform: `scaleX(${pageProgress / 100})`,
-      }"
+      class="page-scroll-progress fixed left-0 right-0 h-1 z-110 origin-left bg-linear-to-r from-primary via-primary/80 to-primary/40 will-change-transform"
+      :style="{ top: 'var(--availability-banner-h, 0px)' }"
       role="progressbar"
-      :aria-valuenow="pageProgress"
+      :aria-valuenow="Math.round(pageProgress)"
       aria-valuemin="0"
       aria-valuemax="100"
       aria-label="Page scroll progress"
     />
 
-    <!-- Non-critical canvas work starts when the browser is idle. -->
-    <LazyParticlesBackground :hydrate-on-idle="2000" />
+    <!-- Full-viewport particles are desktop-only; mobile uses HeroParticles (paused offscreen). -->
+    <LazyParticlesBackground v-if="enableGlobalParticles" :hydrate-on-idle="2000" />
 
     <AppNavbar :active-section="activeSection" />
 
@@ -40,7 +37,7 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted } from 'vue';
+import { onMounted, ref } from 'vue';
 import { usePortfolio } from '~/composables/usePortfolio';
 import { useSmoothedScroll } from '~/composables/useSmoothedScroll';
 
@@ -51,13 +48,26 @@ const { activeSection } = usePortfolio();
 const { pageProgress } = useSmoothedScroll(0.14);
 const { vibeCodingModalMounted } = useVibeCodingModal();
 
+/** Fixed full-viewport particle canvas is too expensive on mobile scroll. */
+const enableGlobalParticles = ref(false);
+
 onMounted(() => {
+  const coarseOrNarrow =
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(max-width: 1023px), (pointer: coarse)').matches;
+  enableGlobalParticles.value = !coarseOrNarrow;
+
   // Defer CRT/scanline paint chrome until after first paint metrics settle.
-  const enableFx = () => document.documentElement.classList.add('fx-on');
-  if (typeof requestIdleCallback === 'function') {
-    requestIdleCallback(enableFx, { timeout: 2500 });
+  // On mobile, never enable full-viewport HUD overlays (also clear a sticky class).
+  if (coarseOrNarrow) {
+    document.documentElement.classList.remove('fx-on');
   } else {
-    setTimeout(enableFx, 1200);
+    const enableFx = () => document.documentElement.classList.add('fx-on');
+    if (typeof requestIdleCallback === 'function') {
+      requestIdleCallback(enableFx, { timeout: 2500 });
+    } else {
+      setTimeout(enableFx, 1200);
+    }
   }
 });
 

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -103,6 +103,11 @@
     line-height: 1.5;
   }
 
+  /* Scroll progress bar — transform driven without Vue per-frame patches */
+  .page-scroll-progress {
+    transform: scaleX(var(--page-progress, 0));
+  }
+
   /* Keep below-the-fold SSR content indexable without paying its layout cost
      during the initial mobile render. The remembered intrinsic size prevents
      jumps after a section is first revealed. */
@@ -174,6 +179,14 @@
   .glass {
     @apply backdrop-blur-2xl border border-foreground/10 shadow-2xl;
     background: var(--glass-bg);
+  }
+
+  /* Mobile scroll budget: keep glass tint/border, cut live backdrop-filter cost. */
+  @media (max-width: 1023px) {
+    .glass {
+      backdrop-filter: blur(8px);
+      -webkit-backdrop-filter: blur(8px);
+    }
   }
 
   .text-gradient {

--- a/app/components/AboutSection.vue
+++ b/app/components/AboutSection.vue
@@ -15,11 +15,11 @@
           :initial="motionInitial({ opacity: 0, x: -50 }, { opacity: 1, x: 0 })"
           :while-in-view="motionInView({ opacity: 1, x: 0 })"
           :viewport="{ once: true }"
-          :transition="{ duration: 1, ease: [0.16, 1, 0.3, 1] }"
+          :transition="motionTransition({ duration: 0.42 })"
           class="xl:col-span-5 xl:sticky xl:top-28 2xl:top-32 w-full max-w-lg mx-auto xl:max-w-none xl:mx-0 min-w-0"
         >
           <div
-            class="surface-card group glass border-white/5 rounded-2xl sm:rounded-3xl xl:rounded-[2.5rem] overflow-hidden p-5 sm:p-7 md:p-8 xl:p-10 shadow-2xl relative bg-background/20 backdrop-blur-3xl min-w-0"
+            class="surface-card group glass border-white/5 rounded-2xl sm:rounded-3xl xl:rounded-[2.5rem] overflow-hidden p-5 sm:p-7 md:p-8 xl:p-10 shadow-2xl relative bg-background/20 backdrop-blur-md md:backdrop-blur-3xl min-w-0"
           >
             <!-- Gamified Energy Border -->
             <div
@@ -83,7 +83,7 @@
             :initial="motionInitial({ opacity: 0, y: 30 }, { opacity: 1, y: 0 })"
             :while-in-view="motionInView({ opacity: 1, y: 0 })"
             :viewport="{ once: true }"
-            :transition="{ duration: 1, ease: [0.16, 1, 0.3, 1] }"
+            :transition="motionTransition({ duration: 0.4 })"
             class="space-y-6 md:space-y-10"
           >
             <div class="flex items-center gap-3 sm:gap-4 justify-center xl:justify-start">
@@ -124,11 +124,7 @@
               :initial="motionInitial({ opacity: 0, y: 20 }, { opacity: 1, y: 0 })"
               :while-in-view="motionInView({ opacity: 1, y: 0 })"
               :viewport="{ once: true }"
-              :transition="{
-                duration: 0.8,
-                delay: i * 0.1,
-                ease: [0.16, 1, 0.3, 1],
-              }"
+              :transition="motionTransition({ duration: 0.4, delay: i * 0.05 })"
               class="h-full min-w-0"
             >
               <article
@@ -352,7 +348,7 @@ import Dialog from 'primevue/dialog';
 import type { PhilosophyPoint } from './PhilosophyPointItem.vue';
 
 const { t, tm } = useI18n();
-const { motionInitial, motionInView } = useMotionConfig();
+const { motionInitial, motionInView, motionTransition } = useMotionConfig();
 
 const roleModalVisible = ref(false);
 const selectedRoleKey = ref<string | null>(null);

--- a/app/components/AppNavbar.vue
+++ b/app/components/AppNavbar.vue
@@ -1,7 +1,7 @@
 ﻿<template>
   <nav
     class="site-nav fixed left-0 right-0 z-130"
-    :style="{ top: 'var(--availability-banner-h, 0px)', '--nav-progress': navProgress }"
+    :style="{ top: 'var(--availability-banner-h, 0px)' }"
   >
     <div
       class="container mx-auto px-3 sm:px-4 md:px-6 lg:px-8 xl:px-12 2xl:px-16 pointer-events-none"
@@ -418,8 +418,8 @@ const props = defineProps({
   },
 });
 
-const { progress } = useSmoothedScroll(0.14);
-const navProgress = progress(120);
+// Keeps the shared scroll RAF alive for --nav-progress / --page-progress on :root.
+useSmoothedScroll(0.14);
 const { href: cvHref, fileName: cvFileName } = useCvDownload();
 const localePath = useLocalePath();
 
@@ -705,6 +705,7 @@ const scrollToSection = (e, href) => {
 
 <style scoped>
 .site-nav {
+  /* --nav-progress published on :root by useSmoothedScroll (direct DOM). */
   --np: var(--nav-progress, 0);
   padding-block: calc(1rem + (1 - var(--np)) * 0.5rem);
 }
@@ -722,6 +723,26 @@ const scrollToSection = (e, href) => {
   backdrop-filter: blur(calc(var(--np) * 24px));
   box-shadow: 0 calc(var(--np) * 16px) calc(var(--np) * 40px)
     color-mix(in srgb, #000000 calc(var(--np) * 12%), transparent);
+}
+
+/* Mobile: static blur + solid-enough fill — avoid animating blur radius / padding every RAF. */
+@media (max-width: 1023px) {
+  .site-nav {
+    padding-block: 0.75rem;
+  }
+
+  .site-nav__shell {
+    padding: 0.35rem;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    background-color: color-mix(in srgb, var(--secondary) 78%, transparent);
+    box-shadow: 0 8px 24px color-mix(in srgb, #000000 10%, transparent);
+  }
+
+  .site-nav__links {
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+  }
 }
 
 .site-nav__brand {

--- a/app/components/CapabilitiesSection.vue
+++ b/app/components/CapabilitiesSection.vue
@@ -10,7 +10,7 @@
       <Motion
         :initial="motionInitial({ opacity: 0, y: 5 }, { opacity: 1, y: 0 })"
         :while-in-view="motionInView({ opacity: 1, y: 0 })"
-        :transition="{ duration: 0.6, ease: [0.22, 1, 0.36, 1] }"
+        :transition="motionTransition({ duration: 0.4 })"
         :viewport="{ once: true, amount: 0.1 }"
         class="max-w-4xl mx-auto text-center space-y-8"
       >
@@ -35,11 +35,7 @@
           :key="cap.key"
           :initial="motionInitial({ opacity: 0, y: 20 }, { opacity: 1, y: 0 })"
           :while-in-view="motionInView({ opacity: 1, y: 0 })"
-          :transition="{
-            duration: 0.8,
-            delay: i * 0.1,
-            ease: [0.16, 1, 0.3, 1],
-          }"
+          :transition="motionTransition({ duration: 0.4, delay: i * 0.05 })"
           :viewport="{ once: true }"
           class="surface-card group relative glass p-6 sm:p-8 md:p-10 lg:p-14 rounded-2xl sm:rounded-[3rem] border-foreground/5 cursor-pointer overflow-hidden h-full"
         >
@@ -95,7 +91,7 @@
 import { Motion } from 'motion-v';
 
 const localePath = useLocalePath();
-const { motionInitial, motionInView } = useMotionConfig();
+const { motionInitial, motionInView, motionTransition } = useMotionConfig();
 
 const capabilities = [
   {

--- a/app/components/CertCompactRow.vue
+++ b/app/components/CertCompactRow.vue
@@ -24,7 +24,7 @@
           <span class="type-meta">{{ cert.date }}</span>
           <span class="text-foreground/20" aria-hidden="true">·</span>
           <span class="inline-flex items-center gap-1.5">
-            <Icon name="simple-icons:linkedin" class="size-3.5 shrink-0" />
+            <Icon :name="issuerIcon" class="size-3.5 shrink-0" />
             {{ cert.issuer }}
           </span>
         </span>
@@ -86,7 +86,7 @@ export interface CertCompactItem {
   url: string;
 }
 
-defineProps<{
+const props = defineProps<{
   cert: CertCompactItem;
   expanded: boolean;
   panelId: string;
@@ -95,6 +95,14 @@ defineProps<{
 defineEmits<{
   toggle: [];
 }>();
+
+const issuerIcon = computed(() => {
+  const key = props.cert.issuer.toLowerCase();
+  if (key.includes('platzi')) return 'simple-icons:platzi';
+  if (key.includes('udemy')) return 'simple-icons:udemy';
+  if (key.includes('new relic')) return 'simple-icons:newrelic';
+  return 'simple-icons:linkedin';
+});
 </script>
 
 <style scoped>

--- a/app/components/CertificationsSection.vue
+++ b/app/components/CertificationsSection.vue
@@ -16,7 +16,7 @@
       <Motion
         :initial="motionInitial({ opacity: 0, y: 20 }, { opacity: 1, y: 0 })"
         :while-in-view="motionInView({ opacity: 1, y: 0 })"
-        :transition="{ duration: 0.8, ease: [0.16, 1, 0.3, 1] }"
+        :transition="motionTransition({ duration: 0.4 })"
         :viewport="{ once: true }"
         class="max-w-4xl lg:max-w-5xl xl:max-w-6xl mx-auto text-center space-y-6 md:space-y-10 mb-12 md:mb-24 px-2 sm:px-0"
       >
@@ -49,11 +49,7 @@
           :key="cert.id"
           :initial="motionInitial({ opacity: 0, y: 20 }, { opacity: 1, y: 0 })"
           :while-in-view="motionInView({ opacity: 1, y: 0 })"
-          :transition="{
-            duration: 0.5,
-            delay: i * 0.05,
-            ease: [0.16, 1, 0.3, 1],
-          }"
+          :transition="motionTransition({ duration: 0.4, delay: i * 0.04 })"
           :viewport="{ once: true }"
           class="surface-card group relative glass p-5 sm:p-6 md:p-8 rounded-4xl border-foreground/5 flex flex-col justify-between h-full overflow-hidden min-w-0"
         >
@@ -76,7 +72,7 @@
                 {{ cert.title }}
               </h4>
               <div class="flex items-center gap-2 text-sm font-medium text-muted">
-                <Icon name="simple-icons:linkedin" class="size-5 shrink-0" />
+                <Icon :name="certIssuerIcon(cert.issuer)" class="size-5 shrink-0" />
                 <span>{{ cert.issuer }}</span>
               </div>
             </div>
@@ -118,7 +114,7 @@
         v-if="restCertifications.length"
         :initial="motionInitial({ opacity: 0, y: 16 }, { opacity: 1, y: 0 })"
         :while-in-view="motionInView({ opacity: 1, y: 0 })"
-        :transition="{ duration: 0.5, ease: [0.16, 1, 0.3, 1] }"
+        :transition="motionTransition({ duration: 0.4 })"
         :viewport="{ once: true }"
         class="glass rounded-3xl md:rounded-4xl border border-foreground/5 overflow-hidden"
       >
@@ -212,13 +208,21 @@ interface CertificationItem {
 const REST_PREVIEW_COUNT = 8;
 
 const { tm, rt } = useI18n();
-const { motionInitial, motionInView } = useMotionConfig();
+const { motionInitial, motionInView, motionTransition } = useMotionConfig();
 
 const expandedId = ref<string | null>(null);
 const showAllRest = ref(false);
 
 function isFeaturedFlag(value: unknown): boolean {
   return value === true || value === 'true';
+}
+
+function certIssuerIcon(issuer: string): string {
+  const key = issuer.toLowerCase();
+  if (key.includes('platzi')) return 'simple-icons:platzi';
+  if (key.includes('udemy')) return 'simple-icons:udemy';
+  if (key.includes('new relic')) return 'simple-icons:newrelic';
+  return 'simple-icons:linkedin';
 }
 
 const certifications = computed<CertificationItem[]>(() => {

--- a/app/components/ContactSection.vue
+++ b/app/components/ContactSection.vue
@@ -21,7 +21,7 @@
         <Motion
           :initial="motionInitial({ opacity: 0, x: -50 }, { opacity: 1, x: 0 })"
           :while-in-view="motionInView({ opacity: 1, x: 0 })"
-          :transition="{ duration: 1, ease: [0.16, 1, 0.3, 1] }"
+          :transition="motionTransition({ duration: 0.42 })"
           :viewport="{ once: true }"
           class="space-y-8 sm:space-y-10 md:space-y-14"
         >
@@ -87,7 +87,7 @@
         <Motion
           :initial="motionInitial({ opacity: 0, x: 50 }, { opacity: 1, x: 0 })"
           :while-in-view="motionInView({ opacity: 1, x: 0 })"
-          :transition="{ duration: 1, delay: 0.3, ease: [0.16, 1, 0.3, 1] }"
+          :transition="motionTransition({ duration: 0.42, delay: 0.08 })"
           :viewport="{ once: true }"
           class="surface-card group glass p-6 sm:p-8 md:p-10 lg:p-12 rounded-[2.5rem] sm:rounded-[3rem] md:rounded-[4rem] border-foreground/5 relative overflow-hidden shadow-4xl mt-12 lg:mt-0"
         >
@@ -284,7 +284,7 @@ import InputText from 'primevue/inputtext';
 import Textarea from 'primevue/textarea';
 import { useContactForm } from '~/composables/useContactForm';
 
-const { motionInitial, motionInView } = useMotionConfig();
+const { motionInitial, motionInView, motionTransition } = useMotionConfig();
 
 const { formData, errors, isSubmitting, submitSuccess, submitError, submitForm } = useContactForm();
 

--- a/app/components/HeroParticles.vue
+++ b/app/components/HeroParticles.vue
@@ -36,7 +36,18 @@ const REPEL_RADIUS = 140;
 const REPEL_STRENGTH = 42;
 const RETURN_EASE = 0.06;
 
+function isMobileBudget() {
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(max-width: 1023px), (pointer: coarse)').matches
+  );
+}
+
 function particleCountForArea(w: number, h: number) {
+  if (isMobileBudget()) {
+    return Math.min(28, Math.max(16, Math.floor((w * h) / 28000)));
+  }
   return Math.min(90, Math.max(36, Math.floor((w * h) / 12000)));
 }
 
@@ -183,7 +194,8 @@ const { pause, resume } = useRafFn(
       drawParticle(particle);
     }
 
-    if (!reduceMotion) connectNearby();
+    // Skip O(n²) connects on mobile — dots alone keep the look without the stroke tax.
+    if (!reduceMotion && !isMobileBudget()) connectNearby();
   },
   { immediate: false },
 );
@@ -192,22 +204,39 @@ function onPointerMove(event: PointerEvent) {
   setPointerFromClient(event.clientX, event.clientY);
 }
 
+let heroVisible = true;
+let intersectionObserver: IntersectionObserver | null = null;
+
+function syncRaf() {
+  if (document.visibilityState === 'visible' && heroVisible) resume();
+  else pause();
+}
+
 onMounted(() => {
   resize();
-  resume();
+  if (containerRef.value && typeof IntersectionObserver !== 'undefined') {
+    intersectionObserver = new IntersectionObserver(
+      ([entry]) => {
+        heroVisible = !!entry?.isIntersecting;
+        syncRaf();
+      },
+      { root: null, rootMargin: '0px', threshold: 0 },
+    );
+    intersectionObserver.observe(containerRef.value);
+  }
+  syncRaf();
 });
 
 onUnmounted(() => {
   pause();
+  intersectionObserver?.disconnect();
+  intersectionObserver = null;
 });
 
 useEventListener(window, 'resize', resize, { passive: true });
 useEventListener(window, 'pointermove', onPointerMove, { passive: true });
 useEventListener(window, 'pointerleave', clearPointer, { passive: true });
-useEventListener(document, 'visibilitychange', () => {
-  if (document.visibilityState === 'visible') resume();
-  else pause();
-});
+useEventListener(document, 'visibilitychange', syncRaf);
 
 watch(prefersReducedMotion, () => {
   initParticles();

--- a/app/components/HireProfilesSection.vue
+++ b/app/components/HireProfilesSection.vue
@@ -2,7 +2,7 @@
 import { Motion } from 'motion-v';
 
 const localePath = useLocalePath();
-const { motionInitial, motionInView } = useMotionConfig();
+const { motionInitial, motionInView, motionTransition } = useMotionConfig();
 
 const profiles = [
   {
@@ -39,7 +39,7 @@ const profiles = [
       <Motion
         :initial="motionInitial({ opacity: 0, y: 16 }, { opacity: 1, y: 0 })"
         :while-in-view="motionInView({ opacity: 1, y: 0 })"
-        :transition="{ duration: 0.6, ease: [0.16, 1, 0.3, 1] }"
+        :transition="motionTransition({ duration: 0.4 })"
         :viewport="{ once: true }"
         class="max-w-3xl mx-auto text-center space-y-5"
       >
@@ -66,11 +66,7 @@ const profiles = [
           :key="profile.key"
           :initial="motionInitial({ opacity: 0, y: 20 }, { opacity: 1, y: 0 })"
           :while-in-view="motionInView({ opacity: 1, y: 0 })"
-          :transition="{
-            duration: 0.55,
-            delay: index * 0.08,
-            ease: [0.16, 1, 0.3, 1],
-          }"
+          :transition="motionTransition({ duration: 0.4, delay: index * 0.05 })"
           :viewport="{ once: true }"
         >
           <NuxtLink

--- a/app/components/ParticlesBackground.vue
+++ b/app/components/ParticlesBackground.vue
@@ -16,6 +16,17 @@ let ctx: CanvasRenderingContext2D | null = null;
 let particles: Particle[] = [];
 let animationFrameId: number | null = null;
 let isPageVisible = true;
+let isMobileBudget = false;
+let isScrolling = false;
+let scrollIdleTimer: ReturnType<typeof setTimeout> | null = null;
+
+function refreshMobileBudget() {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    isMobileBudget = false;
+    return;
+  }
+  isMobileBudget = window.matchMedia('(max-width: 1023px), (pointer: coarse)').matches;
+}
 
 class Particle {
   x: number;
@@ -54,15 +65,29 @@ class Particle {
 }
 
 function shouldAnimate() {
+  // On mobile, pause the full-viewport canvas while the user is scrolling so
+  // GPU/CPU budget goes to scroll compositing (particles resume after idle).
+  if (isMobileBudget && isScrolling) return false;
   return enabled.value && isPageVisible && prefersReducedMotion.value !== 'reduce';
+}
+
+function cssSize() {
+  return {
+    w: window.innerWidth || 1,
+    h: window.innerHeight || 1,
+  };
 }
 
 function initParticles() {
   if (!canvas.value) return;
 
-  const canvasWidth = canvas.value.width;
-  const canvasHeight = canvas.value.height;
-  const particleCount = Math.min(40, Math.floor((canvasWidth * canvasHeight) / 18000));
+  const { w: canvasWidth, h: canvasHeight } = cssSize();
+  const densityDivisor = isMobileBudget ? 42000 : 18000;
+  const maxParticles = isMobileBudget ? 16 : 40;
+  const particleCount = Math.min(
+    maxParticles,
+    Math.floor((canvasWidth * canvasHeight) / densityDivisor),
+  );
 
   particles = [];
   for (let i = 0; i < particleCount; i++) {
@@ -105,14 +130,16 @@ function animate() {
     return;
   }
 
-  ctx.clearRect(0, 0, canvas.value.width, canvas.value.height);
+  const { w, h } = cssSize();
+  ctx.clearRect(0, 0, w, h);
 
   particles.forEach((particle) => {
-    particle.update(canvas.value!.width, canvas.value!.height);
+    particle.update(w, h);
     particle.draw(ctx!);
   });
 
-  connectParticles();
+  // O(n²) strokes are the expensive part — skip on the mobile budget.
+  if (!isMobileBudget) connectParticles();
 
   animationFrameId = requestAnimationFrame(animate);
 }
@@ -130,10 +157,7 @@ function stopAnimation() {
 
 function handleResize() {
   if (!canvas.value) return;
-
-  canvas.value.width = window.innerWidth;
-  canvas.value.height = window.innerHeight;
-  initParticles();
+  setupCanvas();
 }
 
 function handleVisibilityChange() {
@@ -142,14 +166,33 @@ function handleVisibilityChange() {
   else stopAnimation();
 }
 
+function handleScrollBudget() {
+  if (!isMobileBudget) return;
+  const wasScrolling = isScrolling;
+  isScrolling = true;
+  if (!wasScrolling) stopAnimation();
+  if (scrollIdleTimer) clearTimeout(scrollIdleTimer);
+  scrollIdleTimer = setTimeout(() => {
+    isScrolling = false;
+    if (shouldAnimate()) startAnimation();
+  }, 180);
+}
+
 function setupCanvas() {
   if (!canvas.value) return;
 
+  refreshMobileBudget();
+  const { w, h } = cssSize();
+  // Cap DPR on mobile — full retina canvas + particle fills is wasteful.
+  const dpr = isMobileBudget ? 1 : Math.min(window.devicePixelRatio || 1, 2);
+  canvas.value.width = Math.floor(w * dpr);
+  canvas.value.height = Math.floor(h * dpr);
+  canvas.value.style.width = `${w}px`;
+  canvas.value.style.height = `${h}px`;
   ctx = canvas.value.getContext('2d');
-  canvas.value.width = window.innerWidth;
-  canvas.value.height = window.innerHeight;
+  if (ctx) ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
   initParticles();
-  startAnimation();
+  if (shouldAnimate()) startAnimation();
 }
 
 watch(prefersReducedMotion, (value) => {
@@ -163,15 +206,19 @@ watch(prefersReducedMotion, (value) => {
 
 onMounted(() => {
   enabled.value = prefersReducedMotion.value !== 'reduce';
+  refreshMobileBudget();
   window.addEventListener('resize', handleResize);
   document.addEventListener('visibilitychange', handleVisibilityChange);
+  window.addEventListener('scroll', handleScrollBudget, { passive: true });
   if (enabled.value) setupCanvas();
 });
 
 onUnmounted(() => {
   stopAnimation();
+  if (scrollIdleTimer) clearTimeout(scrollIdleTimer);
   window.removeEventListener('resize', handleResize);
   document.removeEventListener('visibilitychange', handleVisibilityChange);
+  window.removeEventListener('scroll', handleScrollBudget);
 });
 </script>
 

--- a/app/components/ProjectsSection.vue
+++ b/app/components/ProjectsSection.vue
@@ -15,7 +15,7 @@
         <Motion
           :initial="motionInitial({ opacity: 0, x: -50 }, { opacity: 1, x: 0 })"
           :while-in-view="motionInView({ opacity: 1, x: 0 })"
-          :transition="{ duration: 1, ease: [0.16, 1, 0.3, 1] }"
+          :transition="motionTransition({ duration: 0.42 })"
           :viewport="{ once: true }"
           class="space-y-8 md:space-y-10 group"
         >
@@ -37,7 +37,7 @@
         <Motion
           :initial="motionInitial({ opacity: 0, scale: 0.9 }, { opacity: 1, scale: 1 })"
           :while-in-view="motionInView({ opacity: 1, scale: 1 })"
-          :transition="{ duration: 0.8, delay: 0.2 }"
+          :transition="motionTransition({ duration: 0.4, delay: 0.06 })"
           :viewport="{ once: true }"
           class="flex flex-wrap gap-2 md:gap-4 p-2 md:p-3 glass rounded-[2.5rem] border-foreground/5 w-fit shadow-xl justify-center lg:justify-start"
         >
@@ -65,11 +65,7 @@
           :key="project.title"
           :initial="motionInitial({ opacity: 0, y: 30 }, { opacity: 1, y: 0 })"
           :while-in-view="motionInView({ opacity: 1, y: 0 })"
-          :transition="{
-            duration: 0.8,
-            delay: i * 0.15,
-            ease: [0.16, 1, 0.3, 1],
-          }"
+          :transition="motionTransition({ duration: 0.4, delay: i * 0.05 })"
           :viewport="{ once: true }"
           class="surface-card group relative glass p-4 sm:p-6 md:p-8 lg:p-10 rounded-2xl sm:rounded-[3rem] md:rounded-[4rem] lg:rounded-[5rem] border-foreground/5 flex flex-col cursor-pointer overflow-hidden h-full"
         >
@@ -151,7 +147,7 @@
       <Motion
         :initial="motionInitial({ opacity: 0, y: 5 }, { opacity: 1, y: 0 })"
         :while-in-view="motionInView({ opacity: 1, y: 0 })"
-        :transition="{ duration: 0.6, delay: 0.3, ease: [0.22, 1, 0.36, 1] }"
+        :transition="motionTransition({ duration: 0.4, delay: 0.08 })"
         :viewport="{ once: true }"
         class="text-center pt-8 md:pt-16"
       >
@@ -177,7 +173,7 @@
 import { Motion } from 'motion-v';
 import { ref, computed } from 'vue';
 
-const { motionInitial, motionInView } = useMotionConfig();
+const { motionInitial, motionInView, motionTransition } = useMotionConfig();
 
 const activeCategory = ref('all');
 const categories = ['all', 'systems', 'fullstack', 'frontend'];

--- a/app/components/TechStackSection.vue
+++ b/app/components/TechStackSection.vue
@@ -15,7 +15,7 @@
       <Motion
         :initial="motionInitial({ opacity: 0, scale: 0.98, y: 5 }, { opacity: 1, scale: 1, y: 0 })"
         :while-in-view="motionInView({ opacity: 1, scale: 1, y: 0 })"
-        :transition="{ duration: 0.7, ease: [0.22, 1, 0.36, 1] }"
+        :transition="motionTransition({ duration: 0.4 })"
         :viewport="{ once: true, amount: 0.1 }"
         class="max-w-4xl mx-auto text-center space-y-8 md:space-y-10 group"
       >
@@ -48,11 +48,7 @@
           :key="t.name"
           :initial="motionInitial({ opacity: 0, y: 20 }, { opacity: 1, y: 0 })"
           :while-in-view="motionInView({ opacity: 1, y: 0 })"
-          :transition="{
-            duration: 0.8,
-            delay: i * 0.1,
-            ease: [0.16, 1, 0.3, 1],
-          }"
+          :transition="motionTransition({ duration: 0.4, delay: i * 0.05 })"
           :viewport="{ once: true }"
           class="surface-card group relative glass p-5 sm:p-6 md:p-8 lg:p-10 rounded-2xl sm:rounded-3xl border-foreground/5 overflow-hidden min-h-0 flex flex-col justify-between cursor-crosshair h-full min-w-0"
         >
@@ -111,7 +107,7 @@
         <Motion
           :initial="motionInitial({ opacity: 0, x: -30 }, { opacity: 1, x: 0 })"
           :while-in-view="motionInView({ opacity: 1, x: 0 })"
-          :transition="{ duration: 1, ease: [0.16, 1, 0.3, 1] }"
+          :transition="motionTransition({ duration: 0.42 })"
           :viewport="{ once: true }"
           class="surface-card surface-card--soft group/hud glass p-6 sm:p-8 md:p-10 lg:p-16 rounded-2xl sm:rounded-[3rem] md:rounded-[4rem] border-foreground/5 space-y-6 sm:space-y-8 md:space-y-10 lg:space-y-12 relative overflow-hidden"
         >
@@ -151,7 +147,7 @@
         <Motion
           :initial="motionInitial({ opacity: 0, x: 30 }, { opacity: 1, x: 0 })"
           :while-in-view="motionInView({ opacity: 1, x: 0 })"
-          :transition="{ duration: 1, ease: [0.16, 1, 0.3, 1] }"
+          :transition="motionTransition({ duration: 0.42, delay: 0.06 })"
           :viewport="{ once: true }"
           class="surface-card surface-card--soft group/hud glass p-10 md:p-16 rounded-[3rem] md:rounded-[4rem] border-foreground/5 flex flex-col justify-between space-y-16 relative overflow-hidden"
         >
@@ -212,7 +208,7 @@ import { useI18n } from 'vue-i18n';
 
 useI18n();
 
-const { motionInitial, motionInView } = useMotionConfig();
+const { motionInitial, motionInView, motionTransition } = useMotionConfig();
 
 const detailedStack = [
   {

--- a/app/components/TestimonialsSection.vue
+++ b/app/components/TestimonialsSection.vue
@@ -7,7 +7,7 @@
       <Motion
         :initial="motionInitial({ opacity: 0, y: 5 }, { opacity: 1, y: 0 })"
         :while-in-view="motionInView({ opacity: 1, y: 0 })"
-        :transition="{ duration: 0.6, ease: [0.22, 1, 0.36, 1] }"
+        :transition="motionTransition({ duration: 0.4 })"
         :viewport="{ once: true, amount: 0.1 }"
         class="max-w-4xl mx-auto text-center space-y-8"
       >
@@ -34,11 +34,7 @@
             motionInitial({ opacity: 0, scale: 0.98, y: 5 }, { opacity: 1, scale: 1, y: 0 })
           "
           :while-in-view="motionInView({ opacity: 1, scale: 1, y: 0 })"
-          :transition="{
-            duration: 0.5,
-            delay: i * 0.1,
-            ease: [0.22, 1, 0.36, 1],
-          }"
+          :transition="motionTransition({ duration: 0.4, delay: i * 0.05 })"
           :viewport="{ once: true, amount: 0.1 }"
           class="surface-card group relative glass p-6 sm:p-8 md:p-14 rounded-3xl sm:rounded-[3.5rem] border-foreground/5 overflow-hidden h-full min-w-0"
         >
@@ -112,7 +108,7 @@ import { Motion } from 'motion-v';
 
 const { tm, rt } = useI18n();
 const { getLocalAvatar, getInitials } = useTestimonialAvatar();
-const { motionInitial, motionInView } = useMotionConfig();
+const { motionInitial, motionInView, motionTransition } = useMotionConfig();
 
 const failedAvatars = ref(new Set<string>());
 

--- a/app/composables/useMotionConfig.ts
+++ b/app/composables/useMotionConfig.ts
@@ -1,44 +1,74 @@
 /**
- * Composable para configuraciones de Motion reutilizables
- * Configuración óptima para evitar el efecto "latido" durante scroll
+ * Shared Motion (motion-v) entrance config.
  *
- * Hydration: prerendered markup must never be opacity-0 after paint. Entrance
- * motion uses transform/scale offsets instead of hiding already-visible content.
+ * - Mobile / coarse pointer: disabled (instant rest state — no while-in-view work).
+ * - Desktop: short transform-only entrances (no opacity fade, small travel).
+ * - prefers-reduced-motion: always disabled.
  */
 
 import { computed } from 'vue';
-import { usePreferredReducedMotion } from '@vueuse/core';
+import { useMediaQuery, usePreferredReducedMotion } from '@vueuse/core';
+
+type MotionState = Record<string, unknown>;
+
+const smoothEase = [0.22, 1, 0.36, 1] as const;
 
 const withoutFade = <T>(state: T): T => {
   if (!state || typeof state !== 'object' || Array.isArray(state)) {
     return state;
   }
 
-  const next = { ...state } as Record<string, unknown>;
+  const next = { ...state } as MotionState;
   if (next.opacity === 0) {
     next.opacity = 1;
   }
   return next as T;
 };
 
+/** Clamp travel so desktop entrances feel crisp, not floaty/clunky. */
+const softenDesktop = <T>(state: T): T => {
+  if (!state || typeof state !== 'object' || Array.isArray(state)) {
+    return state;
+  }
+
+  const next = { ...withoutFade(state) } as MotionState;
+
+  if (typeof next.x === 'number') {
+    next.x = Math.sign(next.x) * Math.min(Math.abs(next.x), 14);
+  }
+  if (typeof next.y === 'number') {
+    next.y = Math.sign(next.y) * Math.min(Math.abs(next.y), 12);
+  }
+  if (typeof next.scale === 'number' && next.scale < 1) {
+    next.scale = Math.max(next.scale, 0.985);
+  }
+  next.opacity = 1;
+
+  return next as T;
+};
+
 export const useMotionConfig = () => {
   const prefersReducedMotion = usePreferredReducedMotion();
+  const isMobileBudget = useMediaQuery('(max-width: 1023px), (pointer: coarse)');
   const nuxtApp = tryUseNuxtApp();
 
-  const motionEnabled = computed(() => prefersReducedMotion.value !== 'reduce');
+  /** Entrance motion only on desktop + when motion is allowed. */
+  const motionEnabled = computed(
+    () => prefersReducedMotion.value !== 'reduce' && !isMobileBudget.value,
+  );
 
   /**
-   * Pre-scroll state. SSR and hydration keep the painted rest state; after that,
-   * animate from transform offsets only — never opacity 0 on visible markup.
+   * Pre-scroll state. SSR/hydration stay at rest; mobile never animates;
+   * desktop uses softened transform offsets (never opacity 0).
    */
   const motionInitial = <T>(hidden: T, visible: T): T => {
-    if (prefersReducedMotion.value === 'reduce') {
+    if (!motionEnabled.value) {
       return visible;
     }
     if (import.meta.server || nuxtApp?.isHydrating) {
       return visible;
     }
-    return withoutFade(hidden);
+    return softenDesktop(hidden);
   };
 
   /** Target while-in-view state — always defined so SSR and client markup match. */
@@ -47,73 +77,64 @@ export const useMotionConfig = () => {
   const motionAnimate = <T>(value: T): T => value;
 
   /**
-   * Configuración base para animaciones sin latido
-   * - amount: 0.1 = solo requiere 10% de visibilidad
-   * - margin: -400px = trigger 400px antes del viewport
-   * - once: true = anima solo una vez
+   * Caps long/clunky transitions. Pass delay for stagger; duration is clamped.
    */
-  const baseViewport = {
-    once: true,
-    amount: 0.1,
-    margin: '0px 0px -400px 0px',
+  const motionTransition = (
+    opts: { duration?: number; delay?: number; ease?: readonly number[] } = {},
+  ) => {
+    if (!motionEnabled.value) {
+      return { duration: 0, delay: 0 };
+    }
+
+    return {
+      duration: Math.min(opts.duration ?? 0.42, 0.5),
+      delay: Math.min(opts.delay ?? 0, 0.12),
+      ease: opts.ease ?? smoothEase,
+    };
   };
 
-  /**
-   * Easing suave y profesional
-   */
-  const smoothEase = [0.19, 1, 0.22, 1] as const;
+  const baseViewport = {
+    once: true,
+    amount: 0.15,
+    // Trigger closer to the viewport so entrances feel intentional, not late/laggy.
+    margin: '0px 0px -10% 0px',
+  };
 
-  /**
-   * Animación de entrada desde la izquierda
-   */
-  const slideInLeft = (duration = 1.4) => ({
-    initial: { opacity: 0, x: -40, scale: 0.9 },
-    whileInView: { opacity: 1, x: 0, scale: 1 },
-    transition: { duration, ease: smoothEase },
+  const slideInLeft = (duration = 0.42) => ({
+    initial: softenDesktop({ opacity: 1, x: -14 }),
+    whileInView: { opacity: 1, x: 0 },
+    transition: motionTransition({ duration }),
     viewport: baseViewport,
   });
 
-  /**
-   * Animación de entrada desde la derecha
-   */
-  const slideInRight = (duration = 1.4) => ({
-    initial: { opacity: 0, x: 40, scale: 0.9 },
-    whileInView: { opacity: 1, x: 0, scale: 1 },
-    transition: { duration, ease: smoothEase },
+  const slideInRight = (duration = 0.42) => ({
+    initial: softenDesktop({ opacity: 1, x: 14 }),
+    whileInView: { opacity: 1, x: 0 },
+    transition: motionTransition({ duration }),
     viewport: baseViewport,
   });
 
-  /**
-   * Animación de entrada desde abajo
-   */
-  const slideInUp = (duration = 1.2) => ({
-    initial: { opacity: 0, y: 50, scale: 0.92 },
-    whileInView: { opacity: 1, y: 0, scale: 1 },
-    transition: { duration, ease: smoothEase },
+  const slideInUp = (duration = 0.4) => ({
+    initial: softenDesktop({ opacity: 1, y: 12 }),
+    whileInView: { opacity: 1, y: 0 },
+    transition: motionTransition({ duration }),
     viewport: baseViewport,
   });
 
-  /**
-   * Animación de fade in simple
-   */
-  const fadeIn = (duration = 1.2) => ({
-    initial: { opacity: 0, scale: 0.95 },
+  const fadeIn = (duration = 0.4) => ({
+    initial: softenDesktop({ opacity: 1, scale: 0.985 }),
     whileInView: { opacity: 1, scale: 1 },
-    transition: { duration, ease: smoothEase },
+    transition: motionTransition({ duration }),
     viewport: baseViewport,
   });
 
-  /**
-   * Animación con delay para stagger
-   */
-  const staggerItem = (index: number, duration = 1.2, delayMultiplier = 0.15) => ({
-    initial: { opacity: 0, y: 50, scale: 0.92 },
-    whileInView: { opacity: 1, y: 0, scale: 1 },
-    transition: {
+  const staggerItem = (index: number, duration = 0.4, delayMultiplier = 0.06) => ({
+    initial: softenDesktop({ opacity: 1, y: 12 }),
+    whileInView: { opacity: 1, y: 0 },
+    transition: motionTransition({
       duration,
       delay: index * delayMultiplier,
-      ease: smoothEase,
-    },
+    }),
     viewport: baseViewport,
   });
 
@@ -122,6 +143,7 @@ export const useMotionConfig = () => {
     motionInitial,
     motionInView,
     motionAnimate,
+    motionTransition,
     baseViewport,
     smoothEase,
     slideInLeft,

--- a/app/composables/useSmoothedScroll.ts
+++ b/app/composables/useSmoothedScroll.ts
@@ -1,8 +1,18 @@
 import { computed, onMounted, onUnmounted, shallowRef, watch } from 'vue';
 import { createSharedComposable, usePreferredReducedMotion, useWindowScroll } from '@vueuse/core';
 
+function isMobileScrollBudget() {
+  return (
+    import.meta.client &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(max-width: 1023px), (pointer: coarse)').matches
+  );
+}
+
 /**
  * Shared lerped scroll — one RAF loop for navbar, progress bar, etc.
+ * On mobile, snap instantly and drive CSS vars via direct DOM to avoid
+ * Vue template patches every animation frame (major scroll-jank source).
  */
 export const useSmoothedScroll = createSharedComposable((lerp = 0.12) => {
   const { y: rawY } = useWindowScroll();
@@ -12,20 +22,45 @@ export const useSmoothedScroll = createSharedComposable((lerp = 0.12) => {
 
   let frame: number | null = null;
   let resizeObserver: ResizeObserver | null = null;
+  let lastPublishedY = Number.NaN;
+
+  const publishChrome = (nextY: number) => {
+    if (!import.meta.client) return;
+    const range = scrollRange.value;
+    const pagePct = range > 0 ? Math.min(1, Math.max(0, nextY / range)) : 0;
+    const navP = Math.min(1, Math.max(0, nextY / 120));
+    const root = document.documentElement;
+    root.style.setProperty('--page-progress', pagePct.toFixed(4));
+    root.style.setProperty('--nav-progress', navP.toFixed(4));
+  };
 
   const step = () => {
     const target = rawY.value;
-    const alpha = prefersReducedMotion.value === 'reduce' ? 1 : lerp;
+    const mobile = isMobileScrollBudget();
+    const alpha = prefersReducedMotion.value === 'reduce' || mobile ? 1 : lerp;
     const delta = target - y.value;
 
+    let next: number;
     if (Math.abs(delta) <= 0.25) {
-      y.value = target;
+      next = target;
       frame = null;
-      return;
+    } else {
+      next = y.value + delta * alpha;
+      frame = requestAnimationFrame(step);
     }
 
-    y.value += delta * alpha;
-    frame = requestAnimationFrame(step);
+    publishChrome(next);
+
+    // On mobile, only poke Vue when the pixel position actually changes.
+    if (mobile) {
+      const rounded = Math.round(next);
+      if (rounded !== lastPublishedY || frame === null) {
+        lastPublishedY = rounded;
+        y.value = next;
+      }
+    } else {
+      y.value = next;
+    }
   };
 
   const scheduleFrame = () => {
@@ -38,13 +73,16 @@ export const useSmoothedScroll = createSharedComposable((lerp = 0.12) => {
       0,
       document.documentElement.scrollHeight - document.documentElement.clientHeight,
     );
+    publishChrome(y.value);
   };
 
   watch(rawY, scheduleFrame, { flush: 'sync' });
 
   onMounted(() => {
     y.value = rawY.value;
+    lastPublishedY = Math.round(rawY.value);
     updateScrollRange();
+    publishChrome(y.value);
 
     resizeObserver = new ResizeObserver(updateScrollRange);
     resizeObserver.observe(document.documentElement);

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,16 +1,17 @@
 <template>
   <main id="main-content" class="portfolio-content relative" tabindex="-1">
     <HeroSection />
-    <LazyAboutSection :hydrate-on-visible="{ rootMargin: '200px' }" />
-    <LazyTechStackSection :hydrate-on-visible="{ rootMargin: '200px' }" />
-    <LazyCertificationsSection :hydrate-on-visible="{ rootMargin: '200px' }" />
-    <LazyCapabilitiesSection :hydrate-on-visible="{ rootMargin: '200px' }" />
+    <!-- Tighter rootMargin reduces hydrate storms when fast-scrolling on mobile. -->
+    <LazyAboutSection :hydrate-on-visible="{ rootMargin: '80px' }" />
+    <LazyTechStackSection :hydrate-on-visible="{ rootMargin: '80px' }" />
+    <LazyCertificationsSection :hydrate-on-visible="{ rootMargin: '80px' }" />
+    <LazyCapabilitiesSection :hydrate-on-visible="{ rootMargin: '80px' }" />
     <!-- <ProjectsSection /> -->
-    <LazyTestimonialsSection :hydrate-on-visible="{ rootMargin: '200px' }" />
-    <LazyHireProfilesSection :hydrate-on-visible="{ rootMargin: '200px' }" />
-    <LazyContactSection :hydrate-on-visible="{ rootMargin: '200px' }" />
-    <LazySeoFaqSection :hydrate-on-visible="{ rootMargin: '200px' }" />
-    <LazyAppFooter :hydrate-on-visible="{ rootMargin: '200px' }" />
+    <LazyTestimonialsSection :hydrate-on-visible="{ rootMargin: '80px' }" />
+    <LazyHireProfilesSection :hydrate-on-visible="{ rootMargin: '80px' }" />
+    <LazyContactSection :hydrate-on-visible="{ rootMargin: '80px' }" />
+    <LazySeoFaqSection :hydrate-on-visible="{ rootMargin: '80px' }" />
+    <LazyAppFooter :hydrate-on-visible="{ rootMargin: '80px' }" />
   </main>
 </template>
 

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -264,18 +264,69 @@
     "collapseCredential": "Hide credential details",
     "data": [
       {
+        "title": "TypeScript for JavaScript Developers",
+        "issuer": "LinkedIn",
+        "date": "Mar. 2025",
+        "skills": ["TypeScript", "Frontend Development", "Web Development"],
+        "url": "https://www.linkedin.com/learning/certificates/f09e41bfbdac073f3af63ea9e6f13c80ee5349969aadf700ef2c6da08a455f3a"
+      },
+      {
         "title": "AI Programming for JavaScript Developers",
         "issuer": "LinkedIn",
         "date": "Mar. 2025",
-        "featured": true,
         "skills": ["Artificial Intelligence", "JavaScript"],
-        "url": "https://www.linkedin.com/learning/certificates/96c7cf924aa3fb572c58f76297d9b67575083a0b87d3627a087b8e0f4fb2864b"
+        "url": "https://www.linkedin.com/learning/certificates/96c7cf924aa3fb572c58f76297d9b67575083a0b87d3627a087b8e0f4fb2864b",
+        "featured": true
+      },
+      {
+        "title": "Data Structures in JavaScript: BSTs, Queues, and Stacks",
+        "issuer": "LinkedIn",
+        "date": "Mar. 2025",
+        "skills": ["JavaScript", "Data Structures"],
+        "url": "https://www.linkedin.com/learning/certificates/d475520bba8320b476a8672294f03f21bdd2709726e6367120b235b13f642975"
+      },
+      {
+        "title": "Scaling TypeScript for Enterprise Developers",
+        "issuer": "LinkedIn",
+        "date": "Mar. 2025",
+        "skills": ["TypeScript", "Web Development", "Frontend Development"],
+        "url": "https://www.linkedin.com/learning/certificates/d5e991f977af403a5925b7afb7b7ef0b833157e33bbf6a04518b31d923406cad",
+        "featured": true
+      },
+      {
+        "title": "Diseña tu propio GPT: ChatGPT como tu empresa lo necesita",
+        "issuer": "LinkedIn",
+        "date": "Mar. 2025",
+        "skills": ["Artificial Intelligence"],
+        "url": "https://www.linkedin.com/learning/certificates/63e19cc1005b97f486b16a26ccd841d8c88e0b5f6cfe93d8870c548c80da973b"
+      },
+      {
+        "title": "Tailwind CSS 4 Essential Training",
+        "issuer": "LinkedIn",
+        "date": "Mar. 2025",
+        "skills": ["Tailwind CSS", "Web Development", "CSS"],
+        "url": "https://www.linkedin.com/learning/certificates/fa28dbebc05524bb23c4af8db2d9d1a4dae8145cdcf564e8fd59469bccdfcdc9",
+        "featured": true
+      },
+      {
+        "title": "Tailwind CSS 3 Essential Training",
+        "issuer": "LinkedIn",
+        "date": "Mar. 2025",
+        "skills": ["Tailwind CSS", "Web Development", "CSS"],
+        "url": "https://www.linkedin.com/learning/certificates/448ce71621db607743e44166e1a2c61aa6c09d1ec5e8d142e60d5a710e9f939a"
+      },
+      {
+        "title": "TypeScript: Object-Oriented Programming",
+        "issuer": "LinkedIn",
+        "date": "Mar. 2025",
+        "skills": ["TypeScript", "OOP"],
+        "url": "https://www.linkedin.com/learning/certificates/a748889d0aebdd7e61871bd7a6069701c626b7d6d2c6a385dcc8502fc23a6873"
       },
       {
         "title": "Building TypeScript Applications with JSDoc",
         "issuer": "LinkedIn",
         "date": "Mar. 2025",
-        "skills": ["Jsdoc", "TypeScript", "TsDoc", "Web Development", "JavaScript"],
+        "skills": ["Jsdoc", "TypeScript", "JavaScript"],
         "url": "https://www.linkedin.com/learning/certificates/2bcd1f72904fbeac332c55811d0247e24229c7ac81c7f8991f943acace2b1560"
       },
       {
@@ -286,124 +337,243 @@
         "url": "https://www.linkedin.com/learning/certificates/914d984cd3d771cea3925268817910cfbec50d4ae1df7bd40133e318271cf820"
       },
       {
-        "title": "Data Structures in JavaScript: BSTs, Queues, and Stacks",
+        "title": "TypeScript avanzado",
         "issuer": "LinkedIn",
         "date": "Mar. 2025",
-        "skills": ["JavaScript", "Data Structures"],
-        "url": "https://www.linkedin.com/learning/certificates/d475520bba8320b476a8672294f03f21bdd2709726e6367120b235b13f642975"
-      },
-      {
-        "title": "Coding Challenge: Functional Programming in JavaScript",
-        "issuer": "LinkedIn",
-        "date": "Mar. 2025",
-        "skills": ["Frontend Development", "Functional Programming", "JavaScript"],
-        "url": "https://www.linkedin.com/learning/certificates/358c7ab887c9b9336c4d198f716c75f97ff11f83d5840b4b461726a765895139"
-      },
-      {
-        "title": "Design your own GPT: ChatGPT for your business",
-        "issuer": "LinkedIn",
-        "date": "Mar. 2025",
-        "skills": ["Artificial Intelligence"],
-        "url": "https://www.linkedin.com/learning/certificates/63e19cc1005b97f486b16a26ccd841d8c88e0b5f6cfe93d8870c548c80da973b"
-      },
-      {
-        "title": "Programming Foundations: Fundamentals",
-        "issuer": "LinkedIn",
-        "date": "Mar. 2025",
-        "skills": [
-          "Programming",
-          "Web Development",
-          "Frontend Development",
-          "Software Development",
-          "Coding Standards"
-        ],
-        "url": "https://www.linkedin.com/learning/certificates/21837bee635ea2e0a3d812fea5848a0c448807c545fd826427cfe7d767f2d863"
-      },
-      {
-        "title": "Advanced JavaScript 1",
-        "issuer": "LinkedIn",
-        "date": "Mar. 2025",
-        "skills": ["Web Development", "Frontend Development", "JavaScript"],
-        "url": "https://www.linkedin.com/learning/certificates/6c7b29eaa587df2c60292bfb8ba7abc87a3c8b41d04a34b969da433fc20237cb"
-      },
-      {
-        "title": "Scaling TypeScript for Enterprise Developers",
-        "issuer": "LinkedIn",
-        "date": "Mar. 2025",
-        "featured": true,
-        "skills": ["TypeScript", "Web Development", "Frontend Development"],
-        "url": "https://www.linkedin.com/learning/certificates/d5e991f977af403a5925b7afb7b7ef0b833157e33bbf6a04518b31d923406cad"
-      },
-      {
-        "title": "Tailwind CSS 3 Essential Training",
-        "issuer": "LinkedIn",
-        "date": "Mar. 2025",
-        "skills": ["Tailwind CSS", "Web Development", "Tailwind", "Frontend Development", "CSS"],
-        "url": "https://www.linkedin.com/learning/certificates/448ce71621db607743e44166e1a2c61aa6c09d1ec5e8d142e60d5a710e9f939a"
-      },
-      {
-        "title": "Tailwind CSS 4 Essential Training",
-        "issuer": "LinkedIn",
-        "date": "Mar. 2025",
-        "featured": true,
-        "skills": ["Tailwind CSS", "Web Development", "Tailwind", "Frontend Development", "CSS"],
-        "url": "https://www.linkedin.com/learning/certificates/fa28dbebc05524bb23c4af8db2d9d1a4dae8145cdcf564e8fd59469bccdfcdc9"
-      },
-      {
-        "title": "Advanced TypeScript",
-        "issuer": "LinkedIn",
-        "date": "Mar. 2025",
-        "featured": true,
-        "skills": ["TypeScript", "Web Development", "Frontend Development"],
+        "skills": ["TypeScript", "Web Development"],
         "url": "https://www.linkedin.com/learning/certificates/b7bae12986a57c4f356f2056a677761b7ba52a71533200169949a2e62580507e"
       },
       {
-        "title": "TypeScript for JavaScript Developers",
+        "title": "Desafío de programación: Programación funcional en JavaScript",
         "issuer": "LinkedIn",
         "date": "Mar. 2025",
-        "skills": ["TypeScript", "Frontend Development", "Web Development"],
-        "url": "https://www.linkedin.com/learning/certificates/f09e41bfbdac073f3af63ea9e6f13c80ee5349969aadf700ef2c6da08a455f3a"
+        "skills": ["Functional Programming", "JavaScript"],
+        "url": "https://www.linkedin.com/learning/certificates/358c7ab887c9b9336c4d198f716c75f97ff11f83d5840b4b461726a765895139"
       },
       {
-        "title": "TypeScript: Object-Oriented Programming",
+        "title": "JavaScript Avanzado 1",
         "issuer": "LinkedIn",
         "date": "Mar. 2025",
-        "skills": ["TypeScript", "Web Development", "Frontend Development", "OOP"],
-        "url": "https://www.linkedin.com/learning/certificates/a748889d0aebdd7e61871bd7a6069701c626b7d6d2c6a385dcc8502fc23a6873"
+        "skills": ["JavaScript", "Web Development"],
+        "url": "https://www.linkedin.com/learning/certificates/6c7b29eaa587df2c60292bfb8ba7abc87a3c8b41d04a34b969da433fc20237cb"
       },
       {
-        "title": "JavaScript Development Specialist",
+        "title": "Fundamentos esenciales de la programación",
+        "issuer": "LinkedIn",
+        "date": "Mar. 2025",
+        "skills": ["Programming", "Web Development"],
+        "url": "https://www.linkedin.com/learning/certificates/21837bee635ea2e0a3d812fea5848a0c448807c545fd826427cfe7d767f2d863"
+      },
+      {
+        "title": "Conviértete en especialista en desarrollo JavaScript",
         "issuer": "LinkedIn",
         "date": "Feb. 2025",
-        "skills": ["Analytic Skills", "Unit Testing", "Debugging", "JavaScript", "Web Development"],
+        "skills": ["JavaScript", "Unit Testing", "Debugging"],
         "url": "https://www.linkedin.com/learning/certificates/e34c91be066bde261fc011a8dd9ce48db9a0cde76e85cdc99cdb929878c09333"
       },
       {
-        "title": "Debug Code: JavaScript",
+        "title": "JavaScript: TDD y pruebas unitarias avanzado",
         "issuer": "LinkedIn",
         "date": "Feb. 2025",
-        "skills": [
-          "Debugging",
-          "Web Development",
-          "Frontend Development",
-          "Software Testing",
-          "JavaScript"
-        ],
+        "skills": ["JavaScript", "TDD", "Unit Testing"],
+        "url": "https://www.linkedin.com/learning/certificates/39925f5c4291f15c949c032fbe0143b2c404661a6145ba52004eaeae45240381"
+      },
+      {
+        "title": "JavaScript: TDD y pruebas unitarias esencial",
+        "issuer": "LinkedIn",
+        "date": "Feb. 2025",
+        "skills": ["JavaScript", "TDD", "Unit Testing"],
+        "url": "https://www.linkedin.com/learning/certificates/757b00cca3dad7ae55d397acd2c9072f6556c59f47db6094bb6d3a9148da235b"
+      },
+      {
+        "title": "Depura el código: JavaScript",
+        "issuer": "LinkedIn",
+        "date": "Feb. 2025",
+        "skills": ["Debugging", "JavaScript"],
         "url": "https://www.linkedin.com/learning/certificates/b37010953715cdd72d83d920083218e663122e5d07203014e503bcfb63b87a6e"
       },
       {
-        "title": "Coding Challenge: Advanced JavaScript",
+        "title": "Desafío de programación: JavaScript avanzado",
         "issuer": "LinkedIn",
         "date": "Feb. 2025",
-        "skills": ["Web Development", "Frontend Development", "JavaScript"],
+        "skills": ["JavaScript", "Web Development"],
         "url": "https://www.linkedin.com/learning/certificates/c2ee8574e7ebdbd3199d696ff9fe5086f6caf3beeea391e48a909ddbdc717195"
       },
       {
-        "title": "Coding Challenge: Basic JavaScript",
+        "title": "Desafío de programación: JavaScript básico",
         "issuer": "LinkedIn",
         "date": "Feb. 2025",
-        "skills": ["Web Development", "Frontend Development", "JavaScript"],
+        "skills": ["JavaScript", "Web Development"],
         "url": "https://www.linkedin.com/learning/certificates/b45a2b1fd3d3e80d040dee6bd6ef58d27ae8c93baabb65152a53aad9f5dc5f40"
+      },
+      {
+        "title": "JavaScript: Trucos",
+        "issuer": "LinkedIn",
+        "date": "Feb. 2025",
+        "skills": ["JavaScript", "Web Development"],
+        "url": "https://www.linkedin.com/learning/certificates/fd2a99cc9e66a0b47b07eb98583845c9c074bd03baa43cf0184d1b51bb4ac094"
+      },
+      {
+        "title": "TypeScript esencial",
+        "issuer": "LinkedIn",
+        "date": "Feb. 2025",
+        "skills": ["TypeScript", "Web Development"],
+        "url": "https://www.linkedin.com/learning/certificates/8604c81d630066943453e8f0c6e1ea87af813091735c0bd7aafaba82e1c88856"
+      },
+      {
+        "title": "JavaScript avanzado: Expresiones regulares",
+        "issuer": "LinkedIn",
+        "date": "Feb. 2025",
+        "skills": ["JavaScript", "Regular Expressions"],
+        "url": "https://www.linkedin.com/learning/certificates/f3acd2efb9ef94dbb6a414cd9fe0ec4f3a0dee693c9f28d7f8b040d6524ebfd7"
+      },
+      {
+        "title": "JavaScript: Errores comunes y cómo solucionarlos",
+        "issuer": "LinkedIn",
+        "date": "Feb. 2025",
+        "skills": ["JavaScript", "Debugging"],
+        "url": "https://www.linkedin.com/learning/certificates/87f711b2f689f57b0ffceb718f0db9fc9586c917627c965e0d9b4b0ec098c473"
+      },
+      {
+        "title": "JavaScript esencial",
+        "issuer": "LinkedIn",
+        "date": "Feb. 2025",
+        "skills": ["JavaScript", "Web Development"],
+        "url": "https://www.linkedin.com/learning/certificates/4231bf08995bd5c0f7b374a499a8aff01e6bd7e23d95abcc1c154f9a8bd6c5d2"
+      },
+      {
+        "title": "Vue: Errores más comunes y cómo solucionarlos",
+        "issuer": "LinkedIn",
+        "date": "Feb. 2025",
+        "skills": ["Vue.js", "Debugging", "SPA"],
+        "url": "https://www.linkedin.com/learning/certificates/e2e91f368173862c3b5871e776dd8471a290dbe69d6f2e58902c55972359190e"
+      },
+      {
+        "title": "Desafío de programación: Vue",
+        "issuer": "LinkedIn",
+        "date": "Feb. 2025",
+        "skills": ["Vue.js", "TypeScript", "SPA"],
+        "url": "https://www.linkedin.com/learning/certificates/b06eb9e3ced2c5bccb4fee241a58f1e729042eaa161bf386b9052945c6f4800c"
+      },
+      {
+        "title": "Vue.js: Testing and Debugging",
+        "issuer": "LinkedIn",
+        "date": "Feb. 2025",
+        "skills": ["Vue.js", "Testing", "Debugging"],
+        "url": "https://www.linkedin.com/learning/certificates/08f8b5e54c8beae6ebbf5f412bbe45401e6e9930c974ba143a0de3231103f2f8"
+      },
+      {
+        "title": "Vue avanzado 1",
+        "issuer": "LinkedIn",
+        "date": "Feb. 2025",
+        "skills": ["Vue.js", "TypeScript", "vue-router"],
+        "url": "https://www.linkedin.com/learning/certificates/5a8a034b7c0a2f5de88c2f572cca2a0789e79cfd3e4a5f66f2697a749d732d73"
+      },
+      {
+        "title": "Vue avanzado 2",
+        "issuer": "LinkedIn",
+        "date": "Feb. 2025",
+        "skills": ["Vue.js", "TypeScript", "vue-router"],
+        "url": "https://www.linkedin.com/learning/certificates/1fb3c4f92cabf9eca1f25c4b5fffc1a567b3d947f6d825a949b3c334ba02bd30"
+      },
+      {
+        "title": "Vue.js esencial",
+        "issuer": "LinkedIn",
+        "date": "Feb. 2025",
+        "skills": ["Vue.js", "vue-router", "SPA"],
+        "url": "https://www.linkedin.com/learning/certificates/1acc2d1334fb46603b4cbdb509bb66a2997970ca9af660e73db5e3951771bba9"
+      },
+      {
+        "title": "New Relic Observability Practitioner Badge",
+        "issuer": "New Relic",
+        "date": "Jul. 2024",
+        "skills": ["Observability", "Monitoring"],
+        "url": "https://credentials.newrelic.com/77cf1600-8c48-4235-b752-e009a8c1a5b9"
+      },
+      {
+        "title": "New Relic Observability Foundations Badge",
+        "issuer": "New Relic",
+        "date": "Jul. 2024",
+        "skills": ["Observability", "Monitoring"],
+        "url": "https://credentials.newrelic.com/9ac61cfa-d45e-48a6-a3f1-286b4fd92a8d"
+      },
+      {
+        "title": "Curso de NPM: Gestión de Paquetes y Dependencias en JavaScript",
+        "issuer": "Platzi",
+        "date": "Oct. 2022",
+        "skills": ["npm", "JavaScript"],
+        "url": "https://platzi.com/p/cgomez16/curso/3578-course/diploma/detalle/"
+      },
+      {
+        "title": "Curso de Vite.js",
+        "issuer": "Platzi",
+        "date": "Oct. 2022",
+        "skills": ["Vite", "TypeScript", "JavaScript"],
+        "url": "https://platzi.com/p/cgomez16/curso/3216-course/diploma/detalle/"
+      },
+      {
+        "title": "Curso de Manipulación de Arrays en JavaScript",
+        "issuer": "Platzi",
+        "date": "Jan. 2022",
+        "skills": ["JavaScript", "Arrays"],
+        "url": "https://platzi.com/p/cgomez16/curso/2461-arrays/diploma/detalle/"
+      },
+      {
+        "title": "Curso de Fundamentos de TypeScript",
+        "issuer": "Platzi",
+        "date": "May. 2022",
+        "skills": ["TypeScript", "JavaScript"],
+        "url": "https://platzi.com/p/cgomez16/curso/2878-typescript/diploma/detalle/"
+      },
+      {
+        "title": "Curso de TypeScript: Tipos Avanzados y Funciones",
+        "issuer": "Platzi",
+        "date": "May. 2022",
+        "skills": ["TypeScript", "JavaScript"],
+        "url": "https://platzi.com/p/cgomez16/curso/2879-typescript-tipos-avanzados/diploma/detalle/"
+      },
+      {
+        "title": "Curso de TypeScript: Programación Orientada a Objetos y Asincronismo",
+        "issuer": "Platzi",
+        "date": "May. 2022",
+        "skills": ["TypeScript", "OOP"],
+        "url": "https://platzi.com/p/cgomez16/curso/2880-typescript-poo/diploma/detalle/"
+      },
+      {
+        "title": "Curso de Vue.js: Componentes y Composition API",
+        "issuer": "Platzi",
+        "date": "May. 2022",
+        "skills": ["Vue.js", "Composition API"],
+        "url": "https://platzi.com/p/cgomez16/curso/2820-vuejs-componentes-composition/diploma/detalle/"
+      },
+      {
+        "title": "Curso Práctico de JavaScript",
+        "issuer": "Platzi",
+        "date": "Jan. 2022",
+        "skills": ["JavaScript", "DOM"],
+        "url": "https://platzi.com/p/cgomez16/curso/2327-course/diploma/detalle/"
+      },
+      {
+        "title": "Curso Profesional de Vue.js",
+        "issuer": "Platzi",
+        "date": "Jan. 2022",
+        "skills": ["Vue.js", "TypeScript"],
+        "url": "https://platzi.com/p/cgomez16/curso/1145-course/diploma/detalle/",
+        "featured": true
+      },
+      {
+        "title": "Curso de Reactividad con Vue.js 3",
+        "issuer": "Platzi",
+        "date": "Feb. 2022",
+        "skills": ["Vue.js", "Reactivity"],
+        "url": "https://platzi.com/p/cgomez16/curso/2167-course/diploma/detalle/"
+      },
+      {
+        "title": "Typescript: tu completa guía de mano",
+        "issuer": "Udemy",
+        "date": "Mar. 2021",
+        "skills": ["TypeScript", "JavaScript"],
+        "url": "https://www.udemy.com/certificate/UC-9f28394d-d043-4c47-b41b-3b4668717fa7/"
       }
     ]
   },

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -264,18 +264,69 @@
     "collapseCredential": "Ocultar detalles de la credencial",
     "data": [
       {
+        "title": "TypeScript for JavaScript Developers",
+        "issuer": "LinkedIn",
+        "date": "Mar. 2025",
+        "skills": ["TypeScript", "Desarrollo front end", "Desarrollo web"],
+        "url": "https://www.linkedin.com/learning/certificates/f09e41bfbdac073f3af63ea9e6f13c80ee5349969aadf700ef2c6da08a455f3a"
+      },
+      {
         "title": "AI Programming for JavaScript Developers",
         "issuer": "LinkedIn",
         "date": "Mar. 2025",
-        "featured": true,
         "skills": ["Inteligencia artificial", "JavaScript"],
-        "url": "https://www.linkedin.com/learning/certificates/96c7cf924aa3fb572c58f76297d9b67575083a0b87d3627a087b8e0f4fb2864b"
+        "url": "https://www.linkedin.com/learning/certificates/96c7cf924aa3fb572c58f76297d9b67575083a0b87d3627a087b8e0f4fb2864b",
+        "featured": true
+      },
+      {
+        "title": "Data Structures in JavaScript: BSTs, Queues, and Stacks",
+        "issuer": "LinkedIn",
+        "date": "Mar. 2025",
+        "skills": ["JavaScript", "Estructuras de datos"],
+        "url": "https://www.linkedin.com/learning/certificates/d475520bba8320b476a8672294f03f21bdd2709726e6367120b235b13f642975"
+      },
+      {
+        "title": "Scaling TypeScript for Enterprise Developers",
+        "issuer": "LinkedIn",
+        "date": "Mar. 2025",
+        "skills": ["TypeScript", "Desarrollo web", "Desarrollo front end"],
+        "url": "https://www.linkedin.com/learning/certificates/d5e991f977af403a5925b7afb7b7ef0b833157e33bbf6a04518b31d923406cad",
+        "featured": true
+      },
+      {
+        "title": "Diseña tu propio GPT: ChatGPT como tu empresa lo necesita",
+        "issuer": "LinkedIn",
+        "date": "Mar. 2025",
+        "skills": ["Inteligencia artificial"],
+        "url": "https://www.linkedin.com/learning/certificates/63e19cc1005b97f486b16a26ccd841d8c88e0b5f6cfe93d8870c548c80da973b"
+      },
+      {
+        "title": "Tailwind CSS 4 Essential Training",
+        "issuer": "LinkedIn",
+        "date": "Mar. 2025",
+        "skills": ["Tailwind CSS", "Desarrollo web", "CSS"],
+        "url": "https://www.linkedin.com/learning/certificates/fa28dbebc05524bb23c4af8db2d9d1a4dae8145cdcf564e8fd59469bccdfcdc9",
+        "featured": true
+      },
+      {
+        "title": "Tailwind CSS 3 Essential Training",
+        "issuer": "LinkedIn",
+        "date": "Mar. 2025",
+        "skills": ["Tailwind CSS", "Desarrollo web", "CSS"],
+        "url": "https://www.linkedin.com/learning/certificates/448ce71621db607743e44166e1a2c61aa6c09d1ec5e8d142e60d5a710e9f939a"
+      },
+      {
+        "title": "TypeScript: Object-Oriented Programming",
+        "issuer": "LinkedIn",
+        "date": "Mar. 2025",
+        "skills": ["TypeScript", "POO"],
+        "url": "https://www.linkedin.com/learning/certificates/a748889d0aebdd7e61871bd7a6069701c626b7d6d2c6a385dcc8502fc23a6873"
       },
       {
         "title": "Building TypeScript Applications with JSDoc",
         "issuer": "LinkedIn",
         "date": "Mar. 2025",
-        "skills": ["Jsdoc", "TypeScript", "TsDoc", "Desarrollo web", "JavaScript"],
+        "skills": ["Jsdoc", "TypeScript", "JavaScript"],
         "url": "https://www.linkedin.com/learning/certificates/2bcd1f72904fbeac332c55811d0247e24229c7ac81c7f8991f943acace2b1560"
       },
       {
@@ -286,124 +337,243 @@
         "url": "https://www.linkedin.com/learning/certificates/914d984cd3d771cea3925268817910cfbec50d4ae1df7bd40133e318271cf820"
       },
       {
-        "title": "Data Structures in JavaScript: BSTs, Queues, and Stacks",
+        "title": "TypeScript avanzado",
         "issuer": "LinkedIn",
         "date": "Mar. 2025",
-        "skills": ["JavaScript", "Estructuras de datos"],
-        "url": "https://www.linkedin.com/learning/certificates/d475520bba8320b476a8672294f03f21bdd2709726e6367120b235b13f642975"
+        "skills": ["TypeScript", "Desarrollo web"],
+        "url": "https://www.linkedin.com/learning/certificates/b7bae12986a57c4f356f2056a677761b7ba52a71533200169949a2e62580507e"
       },
       {
         "title": "Desafío de programación: Programación funcional en JavaScript",
         "issuer": "LinkedIn",
         "date": "Mar. 2025",
-        "skills": ["Desarrollo front end", "Programación funcional", "JavaScript"],
+        "skills": ["Programación funcional", "JavaScript"],
         "url": "https://www.linkedin.com/learning/certificates/358c7ab887c9b9336c4d198f716c75f97ff11f83d5840b4b461726a765895139"
-      },
-      {
-        "title": "Diseña tu propio GPT: ChatGPT como tu empresa lo necesita",
-        "issuer": "LinkedIn",
-        "date": "Mar. 2025",
-        "skills": ["Inteligencia artificial"],
-        "url": "https://www.linkedin.com/learning/certificates/63e19cc1005b97f486b16a26ccd841d8c88e0b5f6cfe93d8870c548c80da973b"
-      },
-      {
-        "title": "Fundamentos esenciales de la programación",
-        "issuer": "LinkedIn",
-        "date": "Mar. 2025",
-        "skills": [
-          "Programación",
-          "Desarrollo web",
-          "Desarrollo front end",
-          "Desarrollo de programas",
-          "Coding Standards"
-        ],
-        "url": "https://www.linkedin.com/learning/certificates/21837bee635ea2e0a3d812fea5848a0c448807c545fd826427cfe7d767f2d863"
       },
       {
         "title": "JavaScript Avanzado 1",
         "issuer": "LinkedIn",
         "date": "Mar. 2025",
-        "skills": ["Desarrollo web", "Desarrollo front end", "JavaScript"],
+        "skills": ["JavaScript", "Desarrollo web"],
         "url": "https://www.linkedin.com/learning/certificates/6c7b29eaa587df2c60292bfb8ba7abc87a3c8b41d04a34b969da433fc20237cb"
       },
       {
-        "title": "Scaling TypeScript for Enterprise Developers",
+        "title": "Fundamentos esenciales de la programación",
         "issuer": "LinkedIn",
         "date": "Mar. 2025",
-        "featured": true,
-        "skills": ["TypeScript", "Desarrollo web", "Desarrollo front end"],
-        "url": "https://www.linkedin.com/learning/certificates/d5e991f977af403a5925b7afb7b7ef0b833157e33bbf6a04518b31d923406cad"
-      },
-      {
-        "title": "Tailwind CSS 3 Essential Training",
-        "issuer": "LinkedIn",
-        "date": "Mar. 2025",
-        "skills": ["Tailwind CSS", "Desarrollo web", "Tailwind", "Desarrollo front end", "CSS"],
-        "url": "https://www.linkedin.com/learning/certificates/448ce71621db607743e44166e1a2c61aa6c09d1ec5e8d142e60d5a710e9f939a"
-      },
-      {
-        "title": "Tailwind CSS 4 Essential Training",
-        "issuer": "LinkedIn",
-        "date": "Mar. 2025",
-        "featured": true,
-        "skills": ["Tailwind CSS", "Desarrollo web", "Tailwind", "Desarrollo front end", "CSS"],
-        "url": "https://www.linkedin.com/learning/certificates/fa28dbebc05524bb23c4af8db2d9d1a4dae8145cdcf564e8fd59469bccdfcdc9"
-      },
-      {
-        "title": "TypeScript avanzado",
-        "issuer": "LinkedIn",
-        "date": "Mar. 2025",
-        "featured": true,
-        "skills": ["TypeScript", "Desarrollo web", "Desarrollo front end"],
-        "url": "https://www.linkedin.com/learning/certificates/b7bae12986a57c4f356f2056a677761b7ba52a71533200169949a2e62580507e"
-      },
-      {
-        "title": "TypeScript for JavaScript Developers",
-        "issuer": "LinkedIn",
-        "date": "Mar. 2025",
-        "skills": ["TypeScript", "Desarrollo front end", "Desarrollo web"],
-        "url": "https://www.linkedin.com/learning/certificates/f09e41bfbdac073f3af63ea9e6f13c80ee5349969aadf700ef2c6da08a455f3a"
-      },
-      {
-        "title": "TypeScript: Object-Oriented Programming",
-        "issuer": "LinkedIn",
-        "date": "Mar. 2025",
-        "skills": ["TypeScript", "Desarrollo web", "Desarrollo front end", "POO"],
-        "url": "https://www.linkedin.com/learning/certificates/a748889d0aebdd7e61871bd7a6069701c626b7d6d2c6a385dcc8502fc23a6873"
+        "skills": ["Programación", "Desarrollo web"],
+        "url": "https://www.linkedin.com/learning/certificates/21837bee635ea2e0a3d812fea5848a0c448807c545fd826427cfe7d767f2d863"
       },
       {
         "title": "Conviértete en especialista en desarrollo JavaScript",
         "issuer": "LinkedIn",
         "date": "Feb. 2025",
-        "skills": [
-          "Capacidad de análisis",
-          "Prueba unitaria",
-          "Depuración",
-          "JavaScript",
-          "Desarrollo web"
-        ],
+        "skills": ["JavaScript", "Prueba unitaria", "Depuración"],
         "url": "https://www.linkedin.com/learning/certificates/e34c91be066bde261fc011a8dd9ce48db9a0cde76e85cdc99cdb929878c09333"
+      },
+      {
+        "title": "JavaScript: TDD y pruebas unitarias avanzado",
+        "issuer": "LinkedIn",
+        "date": "Feb. 2025",
+        "skills": ["JavaScript", "TDD", "Prueba unitaria"],
+        "url": "https://www.linkedin.com/learning/certificates/39925f5c4291f15c949c032fbe0143b2c404661a6145ba52004eaeae45240381"
+      },
+      {
+        "title": "JavaScript: TDD y pruebas unitarias esencial",
+        "issuer": "LinkedIn",
+        "date": "Feb. 2025",
+        "skills": ["JavaScript", "TDD", "Prueba unitaria"],
+        "url": "https://www.linkedin.com/learning/certificates/757b00cca3dad7ae55d397acd2c9072f6556c59f47db6094bb6d3a9148da235b"
       },
       {
         "title": "Depura el código: JavaScript",
         "issuer": "LinkedIn",
         "date": "Feb. 2025",
-        "skills": ["Depuración", "Desarrollo web", "Desarrollo front end", "Pruebas", "JavaScript"],
+        "skills": ["Depuración", "JavaScript"],
         "url": "https://www.linkedin.com/learning/certificates/b37010953715cdd72d83d920083218e663122e5d07203014e503bcfb63b87a6e"
       },
       {
         "title": "Desafío de programación: JavaScript avanzado",
         "issuer": "LinkedIn",
         "date": "Feb. 2025",
-        "skills": ["Desarrollo web", "Desarrollo front end", "JavaScript"],
+        "skills": ["JavaScript", "Desarrollo web"],
         "url": "https://www.linkedin.com/learning/certificates/c2ee8574e7ebdbd3199d696ff9fe5086f6caf3beeea391e48a909ddbdc717195"
       },
       {
         "title": "Desafío de programación: JavaScript básico",
         "issuer": "LinkedIn",
         "date": "Feb. 2025",
-        "skills": ["Desarrollo web", "Desarrollo front end", "JavaScript"],
+        "skills": ["JavaScript", "Desarrollo web"],
         "url": "https://www.linkedin.com/learning/certificates/b45a2b1fd3d3e80d040dee6bd6ef58d27ae8c93baabb65152a53aad9f5dc5f40"
+      },
+      {
+        "title": "JavaScript: Trucos",
+        "issuer": "LinkedIn",
+        "date": "Feb. 2025",
+        "skills": ["JavaScript", "Desarrollo web"],
+        "url": "https://www.linkedin.com/learning/certificates/fd2a99cc9e66a0b47b07eb98583845c9c074bd03baa43cf0184d1b51bb4ac094"
+      },
+      {
+        "title": "TypeScript esencial",
+        "issuer": "LinkedIn",
+        "date": "Feb. 2025",
+        "skills": ["TypeScript", "Desarrollo web"],
+        "url": "https://www.linkedin.com/learning/certificates/8604c81d630066943453e8f0c6e1ea87af813091735c0bd7aafaba82e1c88856"
+      },
+      {
+        "title": "JavaScript avanzado: Expresiones regulares",
+        "issuer": "LinkedIn",
+        "date": "Feb. 2025",
+        "skills": ["JavaScript", "Expresiones regulares"],
+        "url": "https://www.linkedin.com/learning/certificates/f3acd2efb9ef94dbb6a414cd9fe0ec4f3a0dee693c9f28d7f8b040d6524ebfd7"
+      },
+      {
+        "title": "JavaScript: Errores comunes y cómo solucionarlos",
+        "issuer": "LinkedIn",
+        "date": "Feb. 2025",
+        "skills": ["JavaScript", "Depuración"],
+        "url": "https://www.linkedin.com/learning/certificates/87f711b2f689f57b0ffceb718f0db9fc9586c917627c965e0d9b4b0ec098c473"
+      },
+      {
+        "title": "JavaScript esencial",
+        "issuer": "LinkedIn",
+        "date": "Feb. 2025",
+        "skills": ["JavaScript", "Desarrollo web"],
+        "url": "https://www.linkedin.com/learning/certificates/4231bf08995bd5c0f7b374a499a8aff01e6bd7e23d95abcc1c154f9a8bd6c5d2"
+      },
+      {
+        "title": "Vue: Errores más comunes y cómo solucionarlos",
+        "issuer": "LinkedIn",
+        "date": "Feb. 2025",
+        "skills": ["Vue.js", "Depuración", "SPA"],
+        "url": "https://www.linkedin.com/learning/certificates/e2e91f368173862c3b5871e776dd8471a290dbe69d6f2e58902c55972359190e"
+      },
+      {
+        "title": "Desafío de programación: Vue",
+        "issuer": "LinkedIn",
+        "date": "Feb. 2025",
+        "skills": ["Vue.js", "TypeScript", "SPA"],
+        "url": "https://www.linkedin.com/learning/certificates/b06eb9e3ced2c5bccb4fee241a58f1e729042eaa161bf386b9052945c6f4800c"
+      },
+      {
+        "title": "Vue.js: Testing and Debugging",
+        "issuer": "LinkedIn",
+        "date": "Feb. 2025",
+        "skills": ["Vue.js", "Testing", "Depuración"],
+        "url": "https://www.linkedin.com/learning/certificates/08f8b5e54c8beae6ebbf5f412bbe45401e6e9930c974ba143a0de3231103f2f8"
+      },
+      {
+        "title": "Vue avanzado 1",
+        "issuer": "LinkedIn",
+        "date": "Feb. 2025",
+        "skills": ["Vue.js", "TypeScript", "vue-router"],
+        "url": "https://www.linkedin.com/learning/certificates/5a8a034b7c0a2f5de88c2f572cca2a0789e79cfd3e4a5f66f2697a749d732d73"
+      },
+      {
+        "title": "Vue avanzado 2",
+        "issuer": "LinkedIn",
+        "date": "Feb. 2025",
+        "skills": ["Vue.js", "TypeScript", "vue-router"],
+        "url": "https://www.linkedin.com/learning/certificates/1fb3c4f92cabf9eca1f25c4b5fffc1a567b3d947f6d825a949b3c334ba02bd30"
+      },
+      {
+        "title": "Vue.js esencial",
+        "issuer": "LinkedIn",
+        "date": "Feb. 2025",
+        "skills": ["Vue.js", "vue-router", "SPA"],
+        "url": "https://www.linkedin.com/learning/certificates/1acc2d1334fb46603b4cbdb509bb66a2997970ca9af660e73db5e3951771bba9"
+      },
+      {
+        "title": "New Relic Observability Practitioner Badge",
+        "issuer": "New Relic",
+        "date": "Jul. 2024",
+        "skills": ["Observabilidad", "Monitoreo"],
+        "url": "https://credentials.newrelic.com/77cf1600-8c48-4235-b752-e009a8c1a5b9"
+      },
+      {
+        "title": "New Relic Observability Foundations Badge",
+        "issuer": "New Relic",
+        "date": "Jul. 2024",
+        "skills": ["Observabilidad", "Monitoreo"],
+        "url": "https://credentials.newrelic.com/9ac61cfa-d45e-48a6-a3f1-286b4fd92a8d"
+      },
+      {
+        "title": "Curso de NPM: Gestión de Paquetes y Dependencias en JavaScript",
+        "issuer": "Platzi",
+        "date": "Oct. 2022",
+        "skills": ["npm", "JavaScript"],
+        "url": "https://platzi.com/p/cgomez16/curso/3578-course/diploma/detalle/"
+      },
+      {
+        "title": "Curso de Vite.js",
+        "issuer": "Platzi",
+        "date": "Oct. 2022",
+        "skills": ["Vite", "TypeScript", "JavaScript"],
+        "url": "https://platzi.com/p/cgomez16/curso/3216-course/diploma/detalle/"
+      },
+      {
+        "title": "Curso de Manipulación de Arrays en JavaScript",
+        "issuer": "Platzi",
+        "date": "Ene. 2022",
+        "skills": ["JavaScript", "Arrays"],
+        "url": "https://platzi.com/p/cgomez16/curso/2461-arrays/diploma/detalle/"
+      },
+      {
+        "title": "Curso de Fundamentos de TypeScript",
+        "issuer": "Platzi",
+        "date": "May. 2022",
+        "skills": ["TypeScript", "JavaScript"],
+        "url": "https://platzi.com/p/cgomez16/curso/2878-typescript/diploma/detalle/"
+      },
+      {
+        "title": "Curso de TypeScript: Tipos Avanzados y Funciones",
+        "issuer": "Platzi",
+        "date": "May. 2022",
+        "skills": ["TypeScript", "JavaScript"],
+        "url": "https://platzi.com/p/cgomez16/curso/2879-typescript-tipos-avanzados/diploma/detalle/"
+      },
+      {
+        "title": "Curso de TypeScript: Programación Orientada a Objetos y Asincronismo",
+        "issuer": "Platzi",
+        "date": "May. 2022",
+        "skills": ["TypeScript", "POO"],
+        "url": "https://platzi.com/p/cgomez16/curso/2880-typescript-poo/diploma/detalle/"
+      },
+      {
+        "title": "Curso de Vue.js: Componentes y Composition API",
+        "issuer": "Platzi",
+        "date": "May. 2022",
+        "skills": ["Vue.js", "Composition API"],
+        "url": "https://platzi.com/p/cgomez16/curso/2820-vuejs-componentes-composition/diploma/detalle/"
+      },
+      {
+        "title": "Curso Práctico de JavaScript",
+        "issuer": "Platzi",
+        "date": "Ene. 2022",
+        "skills": ["JavaScript", "DOM"],
+        "url": "https://platzi.com/p/cgomez16/curso/2327-course/diploma/detalle/"
+      },
+      {
+        "title": "Curso Profesional de Vue.js",
+        "issuer": "Platzi",
+        "date": "Ene. 2022",
+        "skills": ["Vue.js", "TypeScript"],
+        "url": "https://platzi.com/p/cgomez16/curso/1145-course/diploma/detalle/",
+        "featured": true
+      },
+      {
+        "title": "Curso de Reactividad con Vue.js 3",
+        "issuer": "Platzi",
+        "date": "Feb. 2022",
+        "skills": ["Vue.js", "Reactividad"],
+        "url": "https://platzi.com/p/cgomez16/curso/2167-course/diploma/detalle/"
+      },
+      {
+        "title": "Typescript: tu completa guía de mano",
+        "issuer": "Udemy",
+        "date": "Mar. 2021",
+        "skills": ["TypeScript", "JavaScript"],
+        "url": "https://www.udemy.com/certificate/UC-9f28394d-d043-4c47-b41b-3b4668717fa7/"
       }
     ]
   },


### PR DESCRIPTION
## Summary
- Cut mobile scroll jank: disable entrance motion, pause/offload particles and HUD overlays, snap navbar blur, soften desktop motion-v entrances
- Sync LinkedIn credentials to 44 entries (LinkedIn Learning, Platzi, Udemy, New Relic) with real titles and issuer icons
- Feature Curso Profesional de Vue.js; keep Vue avanzado 1 in the list

## Test plan
- [ ] Mobile: scroll homepage — section entrances should not lag
- [ ] Desktop: entrances feel shorter/snappier
- [ ] Certifications: Show all → Platzi/Udemy/New Relic visible with correct icons/links
- [ ] PageSpeed mobile + desktop on production after merge
