### PR TITLE
ci: move Netlify preview out of reusable CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,9 @@
 name: CI
 
+# Invoked by Deploy (main) and Netlify preview (PRs). No direct pull_request
+# trigger — avoids running validate twice when the preview workflow calls this.
+
 on:
-  pull_request:
-    branches: [main]
-    paths-ignore:
-      - 'redirect/**'
-      - '.github/workflows/deploy.yml'
-      - '**.md'
   workflow_call:
 
 concurrency:
@@ -64,66 +61,3 @@ jobs:
           name: site-${{ github.sha }}
           path: .output/public
           retention-days: 2
-
-  # Same prebuilt artifact as prod — never re-generate on Netlify (buildId/CSP desync).
-  # Stable URL: https://pr-<n>--<site>.netlify.app (alias updates on each PR push).
-  preview:
-    name: Netlify preview
-    if: >
-      github.event_name == 'pull_request' &&
-      github.event.pull_request.head.repo.full_name == github.repository
-    needs: validate
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - name: Download validated site
-        uses: actions/download-artifact@v4
-        with:
-          name: site-${{ github.sha }}
-          path: .output/public
-
-      - name: Deploy preview to Netlify
-        id: deploy
-        env:
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-        run: |
-          set -euo pipefail
-          json=$(npx --yes netlify-cli@latest deploy \
-            --no-build \
-            --dir=.output/public \
-            --alias="pr-${{ github.event.number }}" \
-            --message "PR #${{ github.event.number }} ${GITHUB_SHA}" \
-            --json)
-          echo "$json" | tee /tmp/netlify-deploy.json
-          deploy_url=$(echo "$json" | jq -r '.deploy_url // empty')
-          if [ -z "$deploy_url" ] || [ "$deploy_url" = "null" ]; then
-            echo "::error::Netlify deploy did not return deploy_url"
-            exit 1
-          fi
-          echo "deploy_url=$deploy_url" >> "$GITHUB_OUTPUT"
-          echo "Preview: $deploy_url"
-
-      - name: Comment preview URL on PR
-        env:
-          GH_TOKEN: ${{ github.token }}
-          DEPLOY_URL: ${{ steps.deploy.outputs.deploy_url }}
-          PR_NUMBER: ${{ github.event.number }}
-          REPO: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-          # No git checkout in this job — use the Issues API (not `gh pr comment`).
-          marker='<!-- netlify-deploy-preview -->'
-          body="$(printf '%s\n\n### Netlify Deploy Preview\n\n%s\n\nPrebuilt SSG artifact from CI (`--no-build`). Alias: `pr-%s` — updates on each push to this PR.\n' \
-            "$marker" "$DEPLOY_URL" "$PR_NUMBER")"
-          existing=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
-            --jq ".[] | select(.body | contains(\"${marker}\")) | .id" | head -n1 || true)
-          payload=$(jq -n --arg body "$body" '{body: $body}')
-          if [ -n "${existing}" ]; then
-            echo "$payload" | gh api -X PATCH "repos/${REPO}/issues/comments/${existing}" --input -
-          else
-            echo "$payload" | gh api -X POST "repos/${REPO}/issues/${PR_NUMBER}/comments" --input -
-          fi

--- a/.github/workflows/netlify-preview.yml
+++ b/.github/workflows/netlify-preview.yml
@@ -1,0 +1,79 @@
+name: Netlify preview
+
+# Separate from ci.yml so Deploy-to-Netlify (workflow_call) is not forced to
+# grant pull-requests: write for a job that only runs on PRs.
+
+on:
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - 'redirect/**'
+      - '.github/workflows/deploy.yml'
+      - '**.md'
+
+concurrency:
+  group: netlify-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    uses: ./.github/workflows/ci.yml
+
+  preview:
+    name: Netlify preview
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    needs: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Download validated site
+        uses: actions/download-artifact@v4
+        with:
+          name: site-${{ github.sha }}
+          path: .output/public
+
+      - name: Deploy preview to Netlify
+        id: deploy
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        run: |
+          set -euo pipefail
+          json=$(npx --yes netlify-cli@latest deploy \
+            --no-build \
+            --dir=.output/public \
+            --alias="pr-${{ github.event.number }}" \
+            --message "PR #${{ github.event.number }} ${GITHUB_SHA}" \
+            --json)
+          echo "$json" | tee /tmp/netlify-deploy.json
+          deploy_url=$(echo "$json" | jq -r '.deploy_url // empty')
+          if [ -z "$deploy_url" ] || [ "$deploy_url" = "null" ]; then
+            echo "::error::Netlify deploy did not return deploy_url"
+            exit 1
+          fi
+          echo "deploy_url=$deploy_url" >> "$GITHUB_OUTPUT"
+          echo "Preview: $deploy_url"
+
+      - name: Comment preview URL on PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DEPLOY_URL: ${{ steps.deploy.outputs.deploy_url }}
+          PR_NUMBER: ${{ github.event.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # No git checkout in this job — use the Issues API (not `gh pr comment`).
+          marker='<!-- netlify-deploy-preview -->'
+          body="$(printf '%s\n\n### Netlify Deploy Preview\n\n%s\n\nPrebuilt SSG artifact from CI (`--no-build`). Alias: `pr-%s` — updates on each push to this PR.\n' \
+            "$marker" "$DEPLOY_URL" "$PR_NUMBER")"
+          existing=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
+            --jq ".[] | select(.body | contains(\"${marker}\")) | .id" | head -n1 || true)
+          payload=$(jq -n --arg body "$body" '{body: $body}')
+          if [ -n "${existing}" ]; then
+            echo "$payload" | gh api -X PATCH "repos/${REPO}/issues/comments/${existing}" --input -
+          else
+            echo "$payload" | gh api -X POST "repos/${REPO}/issues/${PR_NUMBER}/comments" --input -
+          fi

--- a/tests/unit/deploy-invariants.spec.ts
+++ b/tests/unit/deploy-invariants.spec.ts
@@ -14,10 +14,13 @@ describe('deploy / layout invariants (regression guards)', () => {
   });
 
   it('publishes a Netlify Deploy Preview from the CI artifact on pull requests', () => {
-    const ci = read('.github/workflows/ci.yml');
-    expect(ci).toMatch(/alias="pr-\$\{\{\s*github\.event\.number\s*\}\}"/);
-    expect(ci).toMatch(/--no-build/);
-    expect(ci).toMatch(/github\.event_name == 'pull_request'/);
+    // Preview lives outside reusable ci.yml so Deploy-to-Netlify is not forced
+    // to grant pull-requests: write for a skipped nested job.
+    const preview = read('.github/workflows/netlify-preview.yml');
+    expect(preview).toMatch(/alias="pr-\$\{\{\s*github\.event\.number\s*\}\}"/);
+    expect(preview).toMatch(/--no-build/);
+    expect(preview).toMatch(/uses:\s*\.\/\.github\/workflows\/ci\.yml/);
+    expect(read('.github/workflows/ci.yml')).not.toMatch(/pull-requests:\s*write/);
   });
 
   it('keeps Netlify HTML post-processing disabled', () => {


### PR DESCRIPTION
﻿## Overview

Follow-up to #3: commit `37fee3f` landed on `perf/lcp-reflow-security-headers` after that PR was merged into `main`, so the Netlify preview workflow split never made it to `main`.

This PR cherry-picks that fix so Deploy-to-Netlify can call the reusable CI workflow without an invalid nested `preview` job that requests `pull-requests: write`.

## Changes

| File | Description |
| --- | --- |
| `.github/workflows/ci.yml` | Make CI `workflow_call`-only; remove nested preview job |
| `.github/workflows/netlify-preview.yml` | Standalone Netlify Deploy Preview workflow |
| `tests/unit/deploy-invariants.spec.ts` | Assert preview lives outside the reusable CI workflow |

## Why

GitHub rejects reusable workflows that nest a job requesting `pull-requests: write` when `ci.yml` is called from `netlify.yml`. Splitting preview into its own workflow restores valid CI + Deploy Preview.
