### PR TITLE
fix: improve PSI a11y, font CLS, and CSP script hashing

### DIFF
--- a/app/components/CertCompactRow.vue
+++ b/app/components/CertCompactRow.vue
@@ -64,9 +64,11 @@ const issuerIcon = computed(() => {
         target="_blank"
         rel="noopener noreferrer"
         class="pointer-events-auto relative z-10 inline-flex min-h-11 min-w-11 shrink-0 items-center justify-center gap-1.5 rounded-xl px-3 glass text-xs font-black uppercase tracking-[0.15em] text-foreground hover:bg-primary hover:text-primary-contrast transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 group/btn"
-        :aria-label="`${$t('certifications.viewCredential')}: ${cert.title}`"
+        :aria-label="$t('certifications.viewCredentialNamed', { title: cert.title })"
       >
-        <span class="hidden sm:inline">{{ $t('certifications.viewCredential') }}</span>
+        <span class="hidden sm:inline" aria-hidden="true">{{
+          $t('certifications.viewCredential')
+        }}</span>
         <Icon
           name="solar:arrow-right-up-linear"
           class="size-5 group-hover/btn:translate-x-0.5 group-hover/btn:-translate-y-0.5 transition-transform"

--- a/app/components/CertificationsSection.vue
+++ b/app/components/CertificationsSection.vue
@@ -178,11 +178,13 @@ watch(showAllRest, () => {
               target="_blank"
               rel="noopener noreferrer"
               class="w-full flex items-center justify-center gap-2 py-3 glass rounded-xl text-sm font-black uppercase tracking-[0.2em] text-foreground hover:bg-primary hover:text-primary-contrast transition-all duration-500 group/btn"
+              :aria-label="$t('certifications.viewCredentialNamed', { title: cert.title })"
             >
-              {{ $t('certifications.viewCredential') }}
+              <span aria-hidden="true">{{ $t('certifications.viewCredential') }}</span>
               <Icon
                 name="solar:arrow-right-up-linear"
                 class="size-5 group-hover/btn:translate-x-0.5 group-hover/btn:-translate-y-0.5 transition-transform"
+                aria-hidden="true"
               />
             </NuxtLink>
           </div>

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -255,6 +255,7 @@
     "titleHighlight": "Certifications.",
     "description": "Technical validation and continuous learning in high-performance ecosystems.",
     "viewCredential": "View Credential",
+    "viewCredentialNamed": "View credential: {title}",
     "skills": "Skills",
     "allCredentials": "All credentials",
     "moreCredentials": "{count} more credentials",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -255,6 +255,7 @@
     "titleHighlight": "Certificaciones.",
     "description": "Validación técnica y aprendizaje continuo en ecosistemas de alto rendimiento.",
     "viewCredential": "Ver Credencial",
+    "viewCredentialNamed": "Ver credencial: {title}",
     "skills": "Aptitudes",
     "allCredentials": "Todas las credenciales",
     "moreCredentials": "{count} credenciales más",

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -152,6 +152,8 @@ export default defineNuxtConfig({
       styles: ['normal'],
       subsets: ['latin'],
     },
+    // --font-main is set via CSS variables; metric-adjusted fallbacks cut CLS on hero name.
+    processCSSVariables: true,
     families: [
       {
         name: 'Outfit',

--- a/package.json
+++ b/package.json
@@ -10,8 +10,9 @@
   "scripts": {
     "build": "nuxt build",
     "dev": "nuxt dev --port 3000",
-    "generate": "nuxt generate && node scripts/inject-entry-css-link.mjs && node scripts/write-csp-headers.mjs",
-    "generate:netlify": "nuxt prepare && node --input-type=module -e \"import fs from 'node:fs'; for (const dir of ['.output', 'dist', 'node_modules/.cache/nuxt']) fs.rmSync(dir, { recursive: true, force: true });\" && nuxt generate && node scripts/inject-entry-css-link.mjs && node scripts/write-csp-headers.mjs",
+    "generate": "nuxt generate && node scripts/inject-entry-css-link.mjs && node scripts/font-display-optional.mjs && node scripts/write-csp-headers.mjs",
+    "generate:netlify": "nuxt prepare && node --input-type=module -e \"import fs from 'node:fs'; for (const dir of ['.output', 'dist', 'node_modules/.cache/nuxt']) fs.rmSync(dir, { recursive: true, force: true });\" && nuxt generate && node scripts/inject-entry-css-link.mjs && node scripts/font-display-optional.mjs && node scripts/write-csp-headers.mjs",
+    "fonts:optional": "node scripts/font-display-optional.mjs",
     "csp:headers": "node scripts/write-csp-headers.mjs",
     "css:link": "node scripts/inject-entry-css-link.mjs",
     "preview": "nuxt preview",

--- a/scripts/font-display-optional.mjs
+++ b/scripts/font-display-optional.mjs
@@ -1,0 +1,52 @@
+/**
+ * After generate, prefer font-display:optional over swap in prerendered HTML.
+ * Metric-adjusted local fallbacks already ship via @nuxt/fonts — optional avoids
+ * a late webfont swap shifting the hero name (PSI CLS on "CESAR").
+ *
+ * Usage: node scripts/font-display-optional.mjs
+ * Honors NUXT_OUTPUT_DIR (default `.output`).
+ */
+import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const outputRoot = process.env.NUXT_OUTPUT_DIR || '.output';
+const publicDir = join(process.cwd(), outputRoot, 'public');
+
+if (!existsSync(publicDir)) {
+  console.error(`[fonts] Missing ${publicDir} — run nuxt generate first`);
+  process.exit(1);
+}
+
+/**
+ * @param {string} dir
+ * @returns {Generator<string>}
+ */
+function* walkHtml(dir) {
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    let st;
+    try {
+      st = statSync(full);
+    } catch {
+      continue;
+    }
+    if (st.isDirectory()) yield* walkHtml(full);
+    else if (name.endsWith('.html')) yield full;
+  }
+}
+
+let files = 0;
+let replacements = 0;
+for (const file of walkHtml(publicDir)) {
+  const html = readFileSync(file, 'utf8');
+  if (!html.includes('font-display:swap')) continue;
+  const next = html.replaceAll('font-display:swap', 'font-display:optional');
+  const count = html.split('font-display:swap').length - 1;
+  writeFileSync(file, next, 'utf8');
+  files += 1;
+  replacements += count;
+}
+
+console.log(
+  `[fonts] font-display:optional in ${files} HTML file(s) (${replacements} @font-face rules)`,
+);

--- a/scripts/lib/csp.mjs
+++ b/scripts/lib/csp.mjs
@@ -4,12 +4,101 @@
  * `.output/public` (`netlify deploy --no-build --dir=...`) — `netlify.toml`
  * [[headers]] are not present in that publish tree.
  *
- * Keep script-src permissive enough for Nuxt SSG inline payloads — see write-csp-headers.mjs.
+ * After generate, write-csp-headers.mjs hashes executable inline `<script>` bodies
+ * so we can drop script-src 'unsafe-inline' while keeping Nuxt SSG payloads.
  */
 
-/** @returns {string[]} */
-export function buildCspDirectives() {
-  return [
+import { createHash } from 'node:crypto';
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * @param {string} dir
+ * @returns {Generator<string>}
+ */
+function* walkHtmlFiles(dir) {
+  if (!existsSync(dir)) return;
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    let st;
+    try {
+      st = statSync(full);
+    } catch {
+      continue;
+    }
+    if (st.isDirectory()) {
+      yield* walkHtmlFiles(full);
+    } else if (name.endsWith('.html')) {
+      yield full;
+    }
+  }
+}
+
+/**
+ * Executable inline scripts only (skip JSON / importmap payloads).
+ * @param {string} html
+ * @returns {string[]}
+ */
+export function extractExecutableInlineScripts(html) {
+  const bodies = [];
+  const re = /<script\b([^>]*)>([\s\S]*?)<\/script>/gi;
+  let match;
+  while ((match = re.exec(html)) !== null) {
+    const attrs = match[1] || '';
+    const body = match[2] ?? '';
+    if (/\bsrc\s*=/i.test(attrs)) continue;
+    if (!body.trim()) continue;
+    const typeMatch = attrs.match(/\btype\s*=\s*["']([^"']+)["']/i);
+    const type = typeMatch?.[1]?.trim().toLowerCase() ?? 'text/javascript';
+    if (
+      type === 'application/json' ||
+      type === 'importmap' ||
+      type === 'application/ld+json' ||
+      type.endsWith('+json')
+    ) {
+      continue;
+    }
+    bodies.push(body);
+  }
+  return bodies;
+}
+
+/** @param {string} content */
+export function hashInlineScript(content) {
+  const digest = createHash('sha256').update(content, 'utf8').digest('base64');
+  return `'sha256-${digest}'`;
+}
+
+/**
+ * @param {string} publicDir
+ * @returns {string[]} sorted unique CSP hash tokens
+ */
+export function collectInlineScriptHashes(publicDir) {
+  const hashes = new Set();
+  for (const file of walkHtmlFiles(publicDir)) {
+    const html = readFileSync(file, 'utf8');
+    for (const body of extractExecutableInlineScripts(html)) {
+      hashes.add(hashInlineScript(body));
+    }
+  }
+  return [...hashes].sort();
+}
+
+/**
+ * @param {{ scriptHashes?: string[], enableTrustedTypes?: boolean }} [options]
+ * @returns {string[]}
+ */
+export function buildCspDirectives(options = {}) {
+  const scriptHashes = options.scriptHashes ?? [];
+  const enableTrustedTypes = options.enableTrustedTypes ?? false;
+
+  const scriptSrc =
+    scriptHashes.length > 0
+      ? ['script-src', "'self'", ...scriptHashes].join(' ')
+      : "script-src 'self' 'unsafe-inline'";
+
+  /** @type {string[]} */
+  const directives = [
     "default-src 'self'",
     "base-uri 'self'",
     "object-src 'none'",
@@ -18,17 +107,27 @@ export function buildCspDirectives() {
     "img-src 'self' data:",
     "font-src 'self'",
     "style-src 'self' 'unsafe-inline'",
-    // Nuxt SSG inlines window.__NUXT__ per HTML; hashes/TT break Vue boot on this stack.
-    "script-src 'self' 'unsafe-inline'",
+    scriptSrc,
     "connect-src 'self'",
     "manifest-src 'self'",
     'upgrade-insecure-requests',
   ];
+
+  if (enableTrustedTypes) {
+    // Vue 3 registers a Trusted Types policy named `vue`.
+    directives.push("require-trusted-types-for 'script'");
+    directives.push('trusted-types vue default');
+  }
+
+  return directives;
 }
 
-/** @returns {string} */
-export function buildCspHeaderValue() {
-  return buildCspDirectives().join('; ');
+/**
+ * @param {{ scriptHashes?: string[], enableTrustedTypes?: boolean }} [options]
+ * @returns {string}
+ */
+export function buildCspHeaderValue(options = {}) {
+  return buildCspDirectives(options).join('; ');
 }
 
 /**

--- a/scripts/write-csp-headers.mjs
+++ b/scripts/write-csp-headers.mjs
@@ -2,20 +2,24 @@
  * After `nuxt generate`, write Netlify `_headers` with a CSP that works with
  * Nuxt SSG + Vue 3 on Netlify.
  *
- * Why not script-src hashes / Trusted Types enforcement?
- * - Nuxt inlines `window.__NUXT__.config` (includes a per-build `buildId`).
- * - `netlify deploy` re-runs `[build].command` even with `--dir`, producing a
- *   second buildId; uploaded HTML and hashed CSP then diverge → Vue never boots.
- * - Vue 3 creates a Trusted Types policy named `vue`, not only `default`.
+ * script-src uses per-build sha256 hashes of executable inline scripts (no
+ * 'unsafe-inline'). Safe because deploy is artifact + `--no-build` (no second
+ * generate that would desync hashes).
  *
- * We still lock down origins, framing, objects, and mixed content.
+ * Trusted Types (`require-trusted-types-for`) stays OFF by default: Vue's
+ * `vue` policy is not enough — other sinks (e.g. innerHTML) still throw under
+ * enforcement. Opt in with NUXT_CSP_TRUSTED_TYPES=1 for experiments only.
  *
  * Usage: node scripts/write-csp-headers.mjs
  * Honors NUXT_OUTPUT_DIR (default `.output`).
  */
 import { writeFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
-import { buildCspHeaderValue, buildNetlifyHeadersFile } from './lib/csp.mjs';
+import {
+  buildCspHeaderValue,
+  buildNetlifyHeadersFile,
+  collectInlineScriptHashes,
+} from './lib/csp.mjs';
 
 const outputRoot = process.env.NUXT_OUTPUT_DIR || '.output';
 const publicDir = join(process.cwd(), outputRoot, 'public');
@@ -25,9 +29,20 @@ if (!existsSync(publicDir)) {
   process.exit(1);
 }
 
-const csp = buildCspHeaderValue();
+const scriptHashes = collectInlineScriptHashes(publicDir);
+if (scriptHashes.length === 0) {
+  console.error(`[csp] No executable inline scripts found under ${publicDir}`);
+  process.exit(1);
+}
+
+const enableTrustedTypes = process.env.NUXT_CSP_TRUSTED_TYPES === '1';
+const csp = buildCspHeaderValue({ scriptHashes, enableTrustedTypes });
 const outFile = join(publicDir, '_headers');
 writeFileSync(outFile, buildNetlifyHeadersFile(csp), 'utf8');
+
 console.log(`[csp] Wrote ${outFile}`);
-console.log(`[csp] script-src 'self' 'unsafe-inline' (hash/TT enforcement disabled for Nuxt SSG)`);
+console.log(`[csp] script-src hashes: ${scriptHashes.length} (no 'unsafe-inline')`);
+console.log(
+  `[csp] Trusted Types: ${enableTrustedTypes ? "require-trusted-types-for 'script'; trusted-types vue default" : 'disabled (set NUXT_CSP_TRUSTED_TYPES=1 to experiment)'}`,
+);
 console.log(`[csp] Also ships HSTS (includeSubDomains; preload), COOP, CORP, and frame guards`);

--- a/tests/e2e/generate-artifacts.spec.ts
+++ b/tests/e2e/generate-artifacts.spec.ts
@@ -15,7 +15,10 @@ test.describe('generate artifacts', () => {
     const headersText = readFileSync(headersPath, 'utf8');
     const csp = parseCspFromHeadersFile(headersText);
     expect(csp).toBeTruthy();
-    expect(csp).toContain("script-src 'self' 'unsafe-inline'");
+    expect(csp).toMatch(/script-src 'self' 'sha256-/);
+    expect(csp).not.toMatch(/script-src[^;]*'unsafe-inline'/);
+    // TT enforcement breaks non-Vue innerHTML sinks on this stack — keep off in prod CSP.
+    expect(csp).not.toContain('require-trusted-types-for');
     expect(csp).toContain("connect-src 'self'");
     // Artifact-only deploy: these must live in _headers, not only netlify.toml.
     expect(headersText).toMatch(/Strict-Transport-Security:.*includeSubDomains.*preload/);

--- a/tests/unit/csp.spec.ts
+++ b/tests/unit/csp.spec.ts
@@ -4,16 +4,41 @@ import {
   buildCspHeaderValue,
   buildNetlifyHeadersFile,
   buildSecurityHeaders,
+  extractExecutableInlineScripts,
+  hashInlineScript,
   parseCspFromHeadersFile,
   parseHeaderFromHeadersFile,
 } from '../../scripts/lib/csp.mjs';
 
 describe('CSP builders', () => {
-  it('allows Nuxt inline scripts without Trusted Types enforcement', () => {
+  it('falls back to unsafe-inline when no script hashes are provided', () => {
     const directives = buildCspDirectives();
     expect(directives).toContain("script-src 'self' 'unsafe-inline'");
     expect(directives.some((d) => d.includes('require-trusted-types-for'))).toBe(false);
-    expect(directives.some((d) => /script-src.*'sha256-/.test(d))).toBe(false);
+  });
+
+  it('uses sha256 hashes and Trusted Types when enabled for generate output', () => {
+    const hash = hashInlineScript('window.__NUXT__={}');
+    const directives = buildCspDirectives({
+      scriptHashes: [hash],
+      enableTrustedTypes: true,
+    });
+    const scriptSrc = directives.find((d) => d.startsWith('script-src'));
+    expect(scriptSrc).toContain(hash);
+    expect(scriptSrc).not.toContain("'unsafe-inline'");
+    expect(directives).toContain("require-trusted-types-for 'script'");
+    expect(directives).toContain('trusted-types vue default');
+  });
+
+  it('hashes only executable inline scripts (skips JSON / src scripts)', () => {
+    const html = `
+      <script src="/a.js"></script>
+      <script type="application/json">{"x":1}</script>
+      <script>window.__NUXT__={}</script>
+    `;
+    const bodies = extractExecutableInlineScripts(html);
+    expect(bodies).toEqual(['window.__NUXT__={}']);
+    expect(hashInlineScript(bodies[0]!)).toMatch(/^'sha256-[A-Za-z0-9+/=]+'$/);
   });
 
   it('locks connect-src to self so Iconify CDN cannot be fetched', () => {
@@ -21,7 +46,10 @@ describe('CSP builders', () => {
   });
 
   it('writes a Netlify _headers file that parses back to the same CSP', () => {
-    const csp = buildCspHeaderValue();
+    const csp = buildCspHeaderValue({
+      scriptHashes: [hashInlineScript('console.log(1)')],
+      enableTrustedTypes: true,
+    });
     const file = buildNetlifyHeadersFile(csp);
     expect(parseCspFromHeadersFile(file)).toBe(csp);
     expect(file).toContain('/*');

--- a/tests/unit/deploy-invariants.spec.ts
+++ b/tests/unit/deploy-invariants.spec.ts
@@ -35,6 +35,13 @@ describe('deploy / layout invariants (regression guards)', () => {
     expect(cspLib).toMatch(/buildSecurityHeaders/);
     expect(cspLib).toMatch(/includeSubDomains/);
     expect(cspLib).toMatch(/Cross-Origin-Opener-Policy/);
+    expect(cspLib).toMatch(/collectInlineScriptHashes/);
+  });
+
+  it('softens webfont swap after generate to cut hero CLS', () => {
+    const pkg = read('package.json');
+    expect(pkg).toMatch(/font-display-optional\.mjs/);
+    expect(read('scripts/font-display-optional.mjs')).toMatch(/font-display:optional/);
   });
 
   it('keeps cssCodeSplit false so CSS preload can target one stylesheet', () => {


### PR DESCRIPTION
﻿## Overview

Improve PageSpeed Insights scores by fixing certification link a11y, cutting hero font CLS, and tightening CSP `script-src` without `'unsafe-inline'`.

## Changes

| File | Description |
| ---- | ----------- |
| `app/components/CertCompactRow.vue` | Unique `viewCredentialNamed` aria-label on compact credential links |
| `app/components/CertificationsSection.vue` | Same unique aria-label on featured credential CTAs |
| `i18n/locales/en.json` / `es.json` | Add `certifications.viewCredentialNamed` |
| `nuxt.config.ts` | Enable `@nuxt/fonts` `processCSSVariables` for metric-adjusted fallbacks |
| `scripts/font-display-optional.mjs` | Post-generate swap→optional to avoid late webfont CLS |
| `package.json` | Wire font-display script into `generate` / `generate:netlify` |
| `scripts/lib/csp.mjs` | Collect sha256 hashes of executable inline scripts; optional Trusted Types |
| `scripts/write-csp-headers.mjs` | Emit hashed `script-src` (no unsafe-inline); TT off by default |
| `tests/unit/csp.spec.ts` / `deploy-invariants.spec.ts` / `tests/e2e/generate-artifacts.spec.ts` | Cover hashing, font-display wiring, and TT-off default |

## Why

PSI flagged duplicate/generic credential link names, font-related CLS on the hero, and CSP with `'unsafe-inline'`. Hashed inline scripts are safe here because deploy is artifact + `--no-build` (no second generate that would desync hashes). Trusted Types stays off by default — Vue's `vue` policy alone still breaks other `innerHTML` sinks; opt in with `NUXT_CSP_TRUSTED_TYPES=1` for experiments only.
