### PR TITLE
perf: keep webfonts off the mobile LCP critical path

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -22,7 +22,8 @@
   --color-border: var(--border);
 
   --font-sans: var(--font-main), ui-sans-serif, system-ui, sans-serif;
-  --font-display: var(--font-main), 'Outfit', 'Inter', sans-serif;
+  /* No Outfit/Inter webfont fallbacks here — they compete with LCP on mobile. */
+  --font-display: var(--font-main);
 
   --animate-float: float 6s ease-in-out infinite;
   --animate-pulse-slow: pulse 4s cubic-bezier(0.4, 0, 0.6, 1) infinite;
@@ -71,7 +72,7 @@
     --primary-hover: #79b8ff;
     --primary-contrast: #000000;
     --secondary: #161b22;
-    --font-main: 'Fira Code', 'Outfit', 'Inter', sans-serif;
+    --font-main: 'Fira Code', ui-sans-serif, system-ui, sans-serif;
 
     background-color: var(--background);
     color: var(--foreground);

--- a/app/utils/themePresets.ts
+++ b/app/utils/themePresets.ts
@@ -22,8 +22,10 @@ export const MUTED_LIGHT = '#64748b';
 
 export const FONT_STACKS: Record<ThemeFont, string> = {
   Sans: '"Outfit", ui-sans-serif, system-ui, sans-serif',
-  // Outfit stays in the stack so missing Fira Code weights (800/900) soft-fallback cleanly
-  'Fira Code': '"Fira Code", "Outfit", ui-sans-serif, system-ui, sans-serif',
+  // Local system fallbacks only — Outfit as a webfont fallback raced Fira on slow 4G
+  // (font-display:optional → skip late Fira → fetch Outfit on the LCP critical path).
+  // Missing Fira weights (800/900) are clamped to 700 in main.css for fira-code themes.
+  'Fira Code': '"Fira Code", ui-sans-serif, system-ui, sans-serif',
 };
 
 export const THEME_PRESETS: ThemePreset[] = [

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -148,7 +148,8 @@ export default defineNuxtConfig({
 
   fonts: {
     defaults: {
-      weights: [400, 500, 600, 700],
+      // Skip 500 — rarely used; fewer @font-face rules on the critical CSS path.
+      weights: [400, 600, 700],
       styles: ['normal'],
       subsets: ['latin'],
     },
@@ -158,17 +159,20 @@ export default defineNuxtConfig({
       {
         name: 'Outfit',
         provider: 'google',
-        // Sans themes + Fira fallback — load globally but keep light
+        // Sans themes only — do not put Outfit in the default Fira stack (see themePresets).
+        // Faces stay global so theme switches work; browser downloads only when used.
         weights: [400, 600, 700],
         preload: false,
         global: true,
       },
       {
-        // Default theme font (`data-theme-font="fira-code"`) — preload for LCP/FCP
+        // Default theme font (`data-theme-font="fira-code"`).
+        // Do NOT preload: LCP is the hero photo; font preload steals slow-4G bandwidth and
+        // still lands on PSI's critical path even with font-display:optional.
         name: 'Fira Code',
         provider: 'google',
         weights: [400, 600, 700],
-        preload: true,
+        preload: false,
       },
     ],
   },

--- a/tests/unit/deploy-invariants.spec.ts
+++ b/tests/unit/deploy-invariants.spec.ts
@@ -44,6 +44,16 @@ describe('deploy / layout invariants (regression guards)', () => {
     expect(read('scripts/font-display-optional.mjs')).toMatch(/font-display:optional/);
   });
 
+  it('does not preload webfonts (LCP is the hero image, not text)', () => {
+    const cfg = read('nuxt.config.ts');
+    // Both families must stay preload:false so slow-4G bandwidth goes to /_ipx me.jpg.
+    expect(cfg).toMatch(/name:\s*'Fira Code'[\s\S]*?preload:\s*false/);
+    expect(cfg).toMatch(/name:\s*'Outfit'[\s\S]*?preload:\s*false/);
+    expect(cfg).not.toMatch(/preload:\s*true/);
+    // Fira stack must not chain a second webfont (Outfit) after optional timeout.
+    expect(read('app/utils/themePresets.ts')).toMatch(/'Fira Code':\s*'"Fira Code", ui-sans-serif/);
+  });
+
   it('keeps cssCodeSplit false so CSS preload can target one stylesheet', () => {
     expect(read('nuxt.config.ts')).toMatch(/cssCodeSplit:\s*false/);
   });


### PR DESCRIPTION
## Summary
- Confirmed PSI's critical-path woff2 (`2msaTeI3`) is **Outfit**, not the preloaded Fira Code file — Fira was still competing via `preload`, and Outfit sat in the default Fira stack so `font-display:optional` could fall through to a second webfont on slow 4G.
- Stop preloading Fira Code; remove Outfit/Inter webfont fallbacks from the default Fira stack and CSS `--font-main` / `--font-display` so bandwidth stays on the hero `/_ipx` image.
- Keep `font-display:optional`, metric-adjusted local fallbacks, hero image preload, and the CSP/hash generate pipeline intact. Add a deploy-invariant guard against font preloads.

## Test plan
- [x] `vitest` deploy-invariants + coverage suite (pre-push)
- [x] `pnpm generate` — 0 `as=font` preloads; image + CSS preloads remain; `font-display:optional`; `--font-main` has Fira + local fallbacks only (no Outfit)
- [ ] Re-run PageSpeed Insights mobile on the Deploy Preview — expect font off / shorter critical path; LCP/FCP improve or hold; CLS stays 0
- [ ] Smoke: default theme (Fira) renders with system fallback if font is late; switching to a Sans theme still loads Outfit