### PR TITLE
perf: defer Fira Code off the LCP critical path

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -2,5 +2,6 @@
   "semi": true,
   "singleQuote": true,
   "trailingComma": "all",
-  "printWidth": 100
+  "printWidth": 100,
+  "endOfLine": "auto"
 }

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -72,7 +72,18 @@
     --primary-hover: #79b8ff;
     --primary-contrast: #000000;
     --secondary: #161b22;
-    --font-main: 'Fira Code', ui-sans-serif, system-ui, sans-serif;
+    /*
+      First paint: metric-adjusted local faces only — do NOT name "Fira Code" here.
+      Naming the webfont makes Chromium fetch /_fonts/*.woff2 on the critical path
+      even with preload:false + font-display:optional (PSI Network Dependency Tree).
+      theme-init / useTheme swap in the webfont after load+idle.
+    */
+    --font-main: 'Fira Code Fallback: BlinkMacSystemFont', 'Fira Code Fallback: Segoe UI',
+      'Fira Code Fallback: Helvetica Neue', 'Fira Code Fallback: Arial',
+      'Fira Code Fallback: Noto Sans', ui-sans-serif, system-ui, sans-serif;
+    /* Unused until activation — keeps @nuxt/fonts metric fallbacks generated. */
+    --font-main-webfont-fira: 'Fira Code', ui-sans-serif, system-ui, sans-serif;
+    --font-main-webfont-outfit: 'Outfit', ui-sans-serif, system-ui, sans-serif;
 
     background-color: var(--background);
     color: var(--foreground);

--- a/app/composables/useTheme.ts
+++ b/app/composables/useTheme.ts
@@ -2,6 +2,7 @@ import { computed, ref, watch } from 'vue';
 import {
   DEFAULT_THEME_ID,
   FONT_STACKS,
+  FONT_STACKS_LOCAL,
   MUTED_DARK,
   MUTED_LIGHT,
   THEME_PRESETS,
@@ -12,7 +13,30 @@ import {
 
 /** Persist theme id without `@vueuse/core` (keeps entry free of the VueUse barrel). */
 const currentThemeId = ref(DEFAULT_THEME_ID);
+
+/** True once webfonts may name "Fira Code" / "Outfit" (after LCP or user theme pick). */
+let webfontsActivated = false;
+let webfontsScheduleStarted = false;
+
+const scheduleWebfontsActivation = (apply: () => void) => {
+  if (webfontsScheduleStarted || webfontsActivated) return;
+  webfontsScheduleStarted = true;
+  const run = () => {
+    if (typeof requestIdleCallback === 'function') {
+      requestIdleCallback(apply, { timeout: 2500 });
+    } else {
+      setTimeout(apply, 1);
+    }
+  };
+  if (document.readyState === 'complete') {
+    run();
+  } else {
+    window.addEventListener('load', run, { once: true });
+  }
+};
+
 if (import.meta.client) {
+  webfontsActivated = document.documentElement.dataset.webfonts === '1';
   try {
     const stored = localStorage.getItem(THEME_STORAGE_KEY);
     if (stored && THEME_PRESETS.some((p) => p.id === stored)) {
@@ -78,7 +102,10 @@ export const useTheme = () => {
     return yiq >= 128 ? '#000000' : '#ffffff';
   };
 
-  const syncCSSVariables = (theme: ThemePreset) => {
+  const syncCSSVariables = (
+    theme: ThemePreset,
+    { activateWebfonts = webfontsActivated }: { activateWebfonts?: boolean } = {},
+  ) => {
     if (!import.meta.client) return;
     const root = document.documentElement;
     const dark = theme.isDark;
@@ -110,7 +137,13 @@ export const useTheme = () => {
       dark ? 'rgba(255, 255, 255, 0.03)' : 'rgba(0, 0, 0, 0.03)',
     );
 
-    root.style.setProperty('--font-main', FONT_STACKS[theme.font]);
+    if (activateWebfonts) {
+      webfontsActivated = true;
+      root.dataset.webfonts = '1';
+      root.style.setProperty('--font-main', FONT_STACKS[theme.font]);
+    } else {
+      root.style.setProperty('--font-main', FONT_STACKS_LOCAL[theme.font]);
+    }
     root.dataset.themeFont = theme.font === 'Fira Code' ? 'fira-code' : 'sans';
   };
 
@@ -121,7 +154,13 @@ export const useTheme = () => {
     apis.updateSurfacePalette(apis.palette(theme.surface));
   };
 
-  const applyTheme = (theme: ThemePreset, { syncPrime = false }: { syncPrime?: boolean } = {}) => {
+  const applyTheme = (
+    theme: ThemePreset,
+    {
+      syncPrime = false,
+      activateWebfonts = webfontsActivated,
+    }: { syncPrime?: boolean; activateWebfonts?: boolean } = {},
+  ) => {
     if (!import.meta.client || !theme) return;
     const root = document.documentElement;
     if (theme.isDark) {
@@ -132,7 +171,7 @@ export const useTheme = () => {
       root.classList.add('light');
     }
 
-    syncCSSVariables(theme);
+    syncCSSVariables(theme, { activateWebfonts });
 
     if (syncPrime) {
       void syncPrimePalettes(theme);
@@ -147,10 +186,18 @@ export const useTheme = () => {
     }
   };
 
-  // Inicializar
+  // Inicializar — keep webfonts deferred until load+idle (or until the user picks a theme).
   if (import.meta.client) {
     const theme = currentTheme.value;
-    if (theme) applyTheme(theme);
+    if (theme) {
+      applyTheme(theme, { activateWebfonts: webfontsActivated });
+      if (!webfontsActivated) {
+        scheduleWebfontsActivation(() => {
+          const latest = currentTheme.value;
+          if (latest) applyTheme(latest, { activateWebfonts: true });
+        });
+      }
+    }
   }
 
   /** Persist + apply (click / Enter). */
@@ -158,20 +205,20 @@ export const useTheme = () => {
     const theme = THEME_PRESETS.find((p) => p.id === id);
     if (theme) {
       currentThemeId.value = id;
-      applyTheme(theme, { syncPrime: true });
+      applyTheme(theme, { syncPrime: true, activateWebfonts: true });
     }
   };
 
   /** Live preview without persisting (keyboard arrow navigation). */
   const previewTheme = (id: string) => {
     const theme = THEME_PRESETS.find((p) => p.id === id);
-    if (theme) applyTheme(theme, { syncPrime: true });
+    if (theme) applyTheme(theme, { syncPrime: true, activateWebfonts: true });
   };
 
   /** Restore the persisted selection (Escape / cancel preview). */
   const cancelThemePreview = () => {
     const theme = currentTheme.value;
-    if (theme) applyTheme(theme, { syncPrime: true });
+    if (theme) applyTheme(theme, { syncPrime: true, activateWebfonts: true });
   };
 
   const toggleTheme = () => {

--- a/app/utils/themeInitScript.ts
+++ b/app/utils/themeInitScript.ts
@@ -1,6 +1,7 @@
 import {
   DEFAULT_THEME_ID,
   FONT_STACKS,
+  FONT_STACKS_LOCAL,
   MUTED_DARK,
   MUTED_LIGHT,
   THEME_PRESETS,
@@ -30,7 +31,8 @@ function toBootstrapEntry(theme: ThemePreset) {
 
 /**
  * Inline script that applies the persisted theme before first paint.
- * Prevents the CSS :root fallback (or default) flashing over the saved palette.
+ * Colors apply immediately; webfonts wait until load+idle so /_fonts/*.woff2
+ * stays off the LCP critical path (metric-adjusted locals paint first).
  */
 export function buildThemeInitScript(): string {
   const map = Object.fromEntries(THEME_PRESETS.map((theme) => [theme.id, toBootstrapEntry(theme)]));
@@ -38,6 +40,10 @@ export function buildThemeInitScript(): string {
     0: FONT_STACKS.Sans,
     1: FONT_STACKS['Fira Code'],
   };
+  const localFonts = {
+    0: FONT_STACKS_LOCAL.Sans,
+    1: FONT_STACKS_LOCAL['Fira Code'],
+  };
 
-  return `(function(){try{var k=${JSON.stringify(THEME_STORAGE_KEY)};var d=${JSON.stringify(DEFAULT_THEME_ID)};var m=${JSON.stringify(map)};var f=${JSON.stringify(fonts)};var md=${JSON.stringify(MUTED_DARK)};var ml=${JSON.stringify(MUTED_LIGHT)};var id=localStorage.getItem(k)||d;var t=m[id]||m[d];if(!t)return;var r=document.documentElement;r.style.setProperty('--primary',t.p);r.style.setProperty('--primary-hover',t.p);r.style.setProperty('--primary-contrast',t.c);r.style.setProperty('--background',t.b);r.style.setProperty('--surface',t.s);r.style.setProperty('--secondary',t.s);r.style.setProperty('--foreground',t.d?'#ffffff':'#0f172a');r.style.setProperty('--muted',t.d?md:ml);r.style.setProperty('--border',t.d?'rgba(255,255,255,0.08)':'rgba(0,0,0,0.08)');r.style.setProperty('--glass-bg',t.d?'rgba(255,255,255,0.03)':'rgba(0,0,0,0.03)');r.style.setProperty('--font-main',f[t.f]);if(/^#[0-9a-fA-F]{6}$/.test(t.p)){r.style.setProperty('--primary-rgb',[1,3,5].map(function(i){return parseInt(t.p.slice(i,i+2),16)}).join(', '));}r.dataset.themeFont=t.f?'fira-code':'sans';if(t.d){r.classList.add('app-dark','dark');r.classList.remove('light')}else{r.classList.add('light');r.classList.remove('app-dark','dark')}}catch(e){}})();`;
+  return `(function(){try{var k=${JSON.stringify(THEME_STORAGE_KEY)};var d=${JSON.stringify(DEFAULT_THEME_ID)};var m=${JSON.stringify(map)};var f=${JSON.stringify(fonts)};var lf=${JSON.stringify(localFonts)};var md=${JSON.stringify(MUTED_DARK)};var ml=${JSON.stringify(MUTED_LIGHT)};var id=localStorage.getItem(k)||d;var t=m[id]||m[d];if(!t)return;var r=document.documentElement;r.style.setProperty('--primary',t.p);r.style.setProperty('--primary-hover',t.p);r.style.setProperty('--primary-contrast',t.c);r.style.setProperty('--background',t.b);r.style.setProperty('--surface',t.s);r.style.setProperty('--secondary',t.s);r.style.setProperty('--foreground',t.d?'#ffffff':'#0f172a');r.style.setProperty('--muted',t.d?md:ml);r.style.setProperty('--border',t.d?'rgba(255,255,255,0.08)':'rgba(0,0,0,0.08)');r.style.setProperty('--glass-bg',t.d?'rgba(255,255,255,0.03)':'rgba(0,0,0,0.03)');r.style.setProperty('--font-main',lf[t.f]);if(/^#[0-9a-fA-F]{6}$/.test(t.p)){r.style.setProperty('--primary-rgb',[1,3,5].map(function(i){return parseInt(t.p.slice(i,i+2),16)}).join(', '));}r.dataset.themeFont=t.f?'fira-code':'sans';if(t.d){r.classList.add('app-dark','dark');r.classList.remove('light')}else{r.classList.add('light');r.classList.remove('app-dark','dark')}var applyWeb=function(){r.style.setProperty('--font-main',f[t.f]);r.dataset.webfonts='1'};var schedule=function(){if(typeof requestIdleCallback==='function'){requestIdleCallback(applyWeb,{timeout:2500})}else{setTimeout(applyWeb,1)}};if(document.readyState==='complete'){schedule()}else{window.addEventListener('load',schedule,{once:true})}}catch(e){}})();`;
 }

--- a/app/utils/themePresets.ts
+++ b/app/utils/themePresets.ts
@@ -20,12 +20,30 @@ export const DEFAULT_THEME_ID = 'github-dark';
 export const MUTED_DARK = '#cbd5e1';
 export const MUTED_LIGHT = '#64748b';
 
+/**
+ * Metric-adjusted local faces from @nuxt/fonts (src:local only).
+ * Used for first paint so the browser never requests /_fonts/*.woff2 on the LCP path.
+ * Names must stay in sync with @nuxt/fonts / fontaine fallback naming.
+ */
+const OUTFIT_LOCAL_FACES =
+  '"Outfit Fallback: BlinkMacSystemFont", "Outfit Fallback: Segoe UI", "Outfit Fallback: Helvetica Neue", "Outfit Fallback: Arial", "Outfit Fallback: Noto Sans"';
+const FIRA_LOCAL_FACES =
+  '"Fira Code Fallback: BlinkMacSystemFont", "Fira Code Fallback: Segoe UI", "Fira Code Fallback: Helvetica Neue", "Fira Code Fallback: Arial", "Fira Code Fallback: Noto Sans"';
+
+/** First-paint stacks — no webfont family name (no network font request). */
+export const FONT_STACKS_LOCAL: Record<ThemeFont, string> = {
+  Sans: `${OUTFIT_LOCAL_FACES}, ui-sans-serif, system-ui, sans-serif`,
+  'Fira Code': `${FIRA_LOCAL_FACES}, ui-sans-serif, system-ui, sans-serif`,
+};
+
+/**
+ * Post-LCP stacks — webfont first, then metric-adjusted locals.
+ * Outfit must not appear in the Fira stack (optional timeout used to race a second webfont).
+ * Missing Fira weights (800/900) are clamped to 700 in main.css for fira-code themes.
+ */
 export const FONT_STACKS: Record<ThemeFont, string> = {
-  Sans: '"Outfit", ui-sans-serif, system-ui, sans-serif',
-  // Local system fallbacks only — Outfit as a webfont fallback raced Fira on slow 4G
-  // (font-display:optional → skip late Fira → fetch Outfit on the LCP critical path).
-  // Missing Fira weights (800/900) are clamped to 700 in main.css for fira-code themes.
-  'Fira Code': '"Fira Code", ui-sans-serif, system-ui, sans-serif',
+  Sans: `"Outfit", ${FONT_STACKS_LOCAL.Sans}`,
+  'Fira Code': `"Fira Code", ${FONT_STACKS_LOCAL['Fira Code']}`,
 };
 
 export const THEME_PRESETS: ThemePreset[] = [

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -169,10 +169,13 @@ export default defineNuxtConfig({
         // Default theme font (`data-theme-font="fira-code"`).
         // Do NOT preload: LCP is the hero photo; font preload steals slow-4G bandwidth and
         // still lands on PSI's critical path even with font-display:optional.
+        // global: ship @font-face even though first paint uses local fallbacks only
+        // (theme-init / useTheme name "Fira Code" only after load+idle).
         name: 'Fira Code',
         provider: 'google',
         weights: [400, 600, 700],
         preload: false,
+        global: true,
       },
     ],
   },

--- a/tests/e2e/generate-artifacts.spec.ts
+++ b/tests/e2e/generate-artifacts.spec.ts
@@ -26,5 +26,14 @@ test.describe('generate artifacts', () => {
 
     const html = readFileSync(indexPath, 'utf8');
     expect(html).toMatch(/rel="preload"[^>]*as="style"/);
+    // Webfonts must stay off the discovery/preload critical path (LCP is the hero image).
+    expect(html).not.toMatch(/rel="preload"[^>]*as="font"/);
+    expect(html).toMatch(/font-display:optional/);
+    expect(html).not.toContain('font-display:swap');
+    // First-paint --font-main uses metric-adjusted locals only (no "Fira Code",… webfont head).
+    expect(html).toMatch(/--font-main:"Fira Code Fallback:/);
+    expect(html).not.toMatch(/--font-main:"Fira Code",/);
+    expect(html).toContain('requestIdleCallback');
+    expect(html).toContain('dataset.webfonts');
   });
 });

--- a/tests/unit/deploy-invariants.spec.ts
+++ b/tests/unit/deploy-invariants.spec.ts
@@ -50,8 +50,25 @@ describe('deploy / layout invariants (regression guards)', () => {
     expect(cfg).toMatch(/name:\s*'Fira Code'[\s\S]*?preload:\s*false/);
     expect(cfg).toMatch(/name:\s*'Outfit'[\s\S]*?preload:\s*false/);
     expect(cfg).not.toMatch(/preload:\s*true/);
-    // Fira stack must not chain a second webfont (Outfit) after optional timeout.
-    expect(read('app/utils/themePresets.ts')).toMatch(/'Fira Code':\s*'"Fira Code", ui-sans-serif/);
+    // Fira ships globally so @font-face exists even when first paint omits the family name.
+    expect(cfg).toMatch(/name:\s*'Fira Code'[\s\S]*?global:\s*true/);
+  });
+
+  it('defers webfont family names until after load (keeps /_fonts off LCP chain)', () => {
+    const presets = read('app/utils/themePresets.ts');
+    const init = read('app/utils/themeInitScript.ts');
+    const css = read('app/assets/css/main.css');
+    expect(presets).toContain('FONT_STACKS_LOCAL');
+    expect(presets).toContain('Fira Code Fallback: Segoe UI');
+    expect(presets).toContain('"Fira Code", ${FONT_STACKS_LOCAL[\'Fira Code\']}');
+    // Blocking theme-init applies local stack first, then load+idle activates webfonts.
+    expect(init).toContain('FONT_STACKS_LOCAL');
+    expect(init).toContain('requestIdleCallback');
+    expect(init).toContain('dataset.webfonts');
+    expect(init).toContain("addEventListener('load'");
+    // CSS :root must not put "Fira Code" in the used --font-main (unused webfont vars OK).
+    expect(css).toMatch(/--font-main:\s*'Fira Code Fallback:/);
+    expect(css).not.toMatch(/--font-main:\s*'Fira Code'/);
   });
 
   it('keeps cssCodeSplit false so CSS preload can target one stylesheet', () => {

--- a/tests/unit/themePresets.spec.ts
+++ b/tests/unit/themePresets.spec.ts
@@ -21,4 +21,14 @@ describe('themePresets', () => {
     }
     expect(script).toContain('localStorage');
   });
+
+  it('applies local font stacks before webfont activation in theme-init', () => {
+    const script = buildThemeInitScript();
+    expect(script).toContain('Fira Code Fallback: Segoe UI');
+    expect(script).toContain('requestIdleCallback');
+    expect(script).toContain("dataset.webfonts='1'");
+    // First --font-main write must use the local map (lf), not the webfont map (f).
+    expect(script).toMatch(/setProperty\('--font-main',lf\[t\.f\]\)/);
+    expect(script).toMatch(/setProperty\('--font-main',f\[t\.f\]\)/);
+  });
 });


### PR DESCRIPTION
## Summary
- **Why Fira stayed critical after #6:** preload was already off and Outfit left the chain, but first paint still named `Fira Code` in `--font-main` (CSS + theme-init). Chromium therefore fetched `/_fonts/*.woff2` from the document → font critical path (~503 ms).
- **Fix:** paint with metric-adjusted local fallbacks first (no webfont family name → no network font request); activate Fira/Outfit on `load` + `requestIdleCallback` (or immediately on theme pick). Keep `preload: false`, `font-display: optional`, Fira `global: true` so faces still ship, and the CSP hash pipeline.
- **Also:** `endOfLine: auto` in Prettier so Windows `core.autocrlf` does not fail `format:check` on push.

## Test plan
- [ ] `pnpm generate` — homepage has no `rel=preload as=font`; `--font-main` starts with `Fira Code Fallback:` (not `Fira Code`,); theme-init schedules webfonts via `requestIdleCallback` / `load`
- [ ] Mobile PSI lab on deploy: Network Dependency Tree should drop `/_fonts/*.woff2` from the LCP chain (expect document → CSS/image only); CLS stays ~0; hero image remains LCP
- [ ] Default theme still looks correct after idle (Fira applies); theme picker still switches fonts immediately
- [ ] CSP still hashes the updated theme-init script (no boot break)