### PR TITLE
fix: clear remaining PSI LCP, CLS, and a11y diagnostics

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -16,15 +16,20 @@ const enableGlobalParticles = ref(false);
 useHead({
   link: [
     {
-      // Match mobile DPR (~1.75–2x) so preload === LCP request (392w for 224 CSS px).
+      // Must match HeroSection NuxtImg sizes/srcset. Generate pipeline re-injects this
+      // at the start of <head> (scripts/lib/lcp-image-preload.mjs) so discovery is not
+      // delayed by theme-init + inlined CSS (~200KB) — that was ~320ms resource load delay.
+      // PSI mobile: 224 CSS px × ~2.625 DPR → 448w.
       rel: 'preload',
       as: 'image',
       type: 'image/webp',
-      href: '/_ipx/f_webp&q_85&fit_cover&s_392x490/img/me.jpg',
+      href: '/_ipx/f_webp&q_85&fit_cover&s_448x560/img/me.jpg',
       fetchpriority: 'high',
-      imagesizes: '224px',
+      tagPriority: 'critical',
+      imagesizes:
+        '(max-width: 640px) 224px, (max-width: 1024px) 256px, (max-width: 1280px) 392px, 448px',
       imagesrcset:
-        '/_ipx/f_webp&q_85&fit_cover&s_224x280/img/me.jpg 224w, /_ipx/f_webp&q_85&fit_cover&s_392x490/img/me.jpg 392w, /_ipx/f_webp&q_85&fit_cover&s_448x560/img/me.jpg 448w',
+        '/_ipx/f_webp&q_85&fit_cover&s_224x280/img/me.jpg 224w, /_ipx/f_webp&q_85&fit_cover&s_256x320/img/me.jpg 256w, /_ipx/f_webp&q_85&fit_cover&s_392x490/img/me.jpg 392w, /_ipx/f_webp&q_85&fit_cover&s_448x560/img/me.jpg 448w',
     },
   ],
 });

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -78,9 +78,9 @@
       even with preload:false + font-display:optional (PSI Network Dependency Tree).
       theme-init / useTheme swap in the webfont after load+idle.
     */
-    --font-main: 'Fira Code Fallback: BlinkMacSystemFont', 'Fira Code Fallback: Segoe UI',
-      'Fira Code Fallback: Helvetica Neue', 'Fira Code Fallback: Arial',
-      'Fira Code Fallback: Noto Sans', ui-sans-serif, system-ui, sans-serif;
+    /* Mono metric fallbacks — must match FONT_STACKS_LOCAL / @nuxt/fonts Fira fallbacks. */
+    --font-main: 'Fira Code Fallback: Consolas', 'Fira Code Fallback: Monaco',
+      'Fira Code Fallback: Menlo', 'Fira Code Fallback: Courier New', ui-monospace, monospace;
     /* Unused until activation — keeps @nuxt/fonts metric fallbacks generated. */
     --font-main-webfont-fira: 'Fira Code', ui-sans-serif, system-ui, sans-serif;
     --font-main-webfont-outfit: 'Outfit', ui-sans-serif, system-ui, sans-serif;

--- a/app/components/AppFooter.vue
+++ b/app/components/AppFooter.vue
@@ -44,11 +44,20 @@ const footerColumns: FooterColumn[] = [
 ];
 
 const socials = [
-  { icon: 'simple-icons:linkedin', link: 'https://linkedin.com/in/mrcego' },
-  { icon: 'simple-icons:github', link: 'https://github.com/mrcego' },
+  {
+    icon: 'simple-icons:linkedin',
+    link: 'https://linkedin.com/in/mrcego',
+    labelKey: 'footer.socialLinkedIn',
+  },
+  {
+    icon: 'simple-icons:github',
+    link: 'https://github.com/mrcego',
+    labelKey: 'footer.socialGitHub',
+  },
   {
     icon: 'solar:letter-bold-duotone',
     link: 'mailto:cesargomezh90@gmail.com',
+    labelKey: 'footer.socialEmail',
   },
 ];
 </script>
@@ -165,7 +174,7 @@ const socials = [
             :key="s.icon"
             :href="s.link"
             class="size-11 md:size-12 glass rounded-xl md:rounded-2xl border border-foreground/10 hover:border-primary/40 flex items-center justify-center transition-all duration-300 hover:scale-105 hover:shadow-[0_0_20px_rgba(255,75,92,0.35)] group/social"
-            aria-label="Social Link"
+            :aria-label="$t(s.labelKey)"
           >
             <Icon
               :name="s.icon"

--- a/app/components/HeroSection.vue
+++ b/app/components/HeroSection.vue
@@ -326,14 +326,10 @@ onMounted(() => {
                   <div
                     class="absolute bottom-4 right-4 md:bottom-6 md:right-6 z-20 glass px-3 py-2 rounded-full flex items-center gap-2.5 border border-primary/20 bg-background/60 backdrop-blur-md shadow-lg animate-pulse-slow"
                   >
-                    <span class="relative flex h-2 w-2 md:h-2.5 md:w-2.5">
-                      <span
-                        class="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-500 opacity-75"
-                      />
-                      <span
-                        class="relative inline-flex rounded-full h-2 w-2 md:h-2.5 md:w-2.5 bg-emerald-500"
-                      />
-                    </span>
+                    <span
+                      class="inline-flex rounded-full h-2 w-2 md:h-2.5 md:w-2.5 bg-emerald-500 shrink-0"
+                      aria-hidden="true"
+                    />
                     <div class="flex flex-col gap-0.5">
                       <span class="type-meta text-primary leading-none">
                         {{ $t('hero.hud.status') }}

--- a/app/utils/themePresets.ts
+++ b/app/utils/themePresets.ts
@@ -24,16 +24,20 @@ export const MUTED_LIGHT = '#64748b';
  * Metric-adjusted local faces from @nuxt/fonts (src:local only).
  * Used for first paint so the browser never requests /_fonts/*.woff2 on the LCP path.
  * Names must stay in sync with @nuxt/fonts / fontaine fallback naming.
+ *
+ * Fira Code is monospace — proportional sans fallbacks (Segoe UI, Arial) still shift
+ * the hero name when webfonts activate after idle. Use mono locals so size-adjust
+ * can match advance widths when "Fira Code" is swapped in.
  */
 const OUTFIT_LOCAL_FACES =
   '"Outfit Fallback: BlinkMacSystemFont", "Outfit Fallback: Segoe UI", "Outfit Fallback: Helvetica Neue", "Outfit Fallback: Arial", "Outfit Fallback: Noto Sans"';
 const FIRA_LOCAL_FACES =
-  '"Fira Code Fallback: BlinkMacSystemFont", "Fira Code Fallback: Segoe UI", "Fira Code Fallback: Helvetica Neue", "Fira Code Fallback: Arial", "Fira Code Fallback: Noto Sans"';
+  '"Fira Code Fallback: Consolas", "Fira Code Fallback: Monaco", "Fira Code Fallback: Menlo", "Fira Code Fallback: Courier New"';
 
 /** First-paint stacks — no webfont family name (no network font request). */
 export const FONT_STACKS_LOCAL: Record<ThemeFont, string> = {
   Sans: `${OUTFIT_LOCAL_FACES}, ui-sans-serif, system-ui, sans-serif`,
-  'Fira Code': `${FIRA_LOCAL_FACES}, ui-sans-serif, system-ui, sans-serif`,
+  'Fira Code': `${FIRA_LOCAL_FACES}, ui-monospace, monospace`,
 };
 
 /**

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -937,7 +937,10 @@
     "protocol": "Ancelab.",
     "status": "All Systems Operational",
     "navLabel": "Footer links",
-    "email": "Email Cesar"
+    "email": "Email Cesar",
+    "socialLinkedIn": "Visit LinkedIn profile",
+    "socialGitHub": "Visit GitHub profile",
+    "socialEmail": "Email Cesar"
   },
   "col": {
     "nav": "Navigation",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -937,7 +937,10 @@
     "protocol": "Ancelab.",
     "status": "Todos los Sistemas Operativos",
     "navLabel": "Enlaces del pie de página",
-    "email": "Escribir a César"
+    "email": "Escribir a César",
+    "socialLinkedIn": "Visitar perfil de LinkedIn",
+    "socialGitHub": "Visitar perfil de GitHub",
+    "socialEmail": "Escribir a César"
   },
   "col": {
     "nav": "Navegación",

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -171,11 +171,14 @@ export default defineNuxtConfig({
         // still lands on PSI's critical path even with font-display:optional.
         // global: ship @font-face even though first paint uses local fallbacks only
         // (theme-init / useTheme name "Fira Code" only after load+idle).
+        // Mono fallbacks so deferred webfont activation does not CLS the hero name
+        // (proportional Segoe/Arial metrics cannot match a monospace face).
         name: 'Fira Code',
         provider: 'google',
         weights: [400, 600, 700],
         preload: false,
         global: true,
+        fallbacks: ['Consolas', 'Monaco', 'Menlo', 'Courier New'],
       },
     ],
   },

--- a/scripts/inject-entry-css-link.mjs
+++ b/scripts/inject-entry-css-link.mjs
@@ -24,7 +24,8 @@ if (!existsSync(nuxtDir)) {
 }
 
 try {
-  const { href, updated } = injectEntryCssLinkIntoPublicDir(publicDir);
+  const { href, updated, lcpUpdated } = injectEntryCssLinkIntoPublicDir(publicDir);
+  console.log(`[css-link] Preloaded LCP image in ${lcpUpdated} HTML file(s)`);
   console.log(`[css-link] Preloaded ${href} in ${updated} HTML file(s)`);
 } catch (error) {
   console.error(error instanceof Error ? error.message : error);

--- a/scripts/lib/entry-css-link.mjs
+++ b/scripts/lib/entry-css-link.mjs
@@ -1,9 +1,14 @@
 /**
- * Helpers for injecting an early CSS preload into generated HTML.
+ * Helpers for injecting early critical preloads into generated HTML.
  * Used by scripts/inject-entry-css-link.mjs and unit tests.
+ *
+ * Order after <head>: LCP image (fetchpriority=high), then CSS preload.
+ * Image must precede the ~200KB inline style block or resource load delay
+ * stays hundreds of ms even when a late useHead preload exists.
  */
 import { readdirSync, readFileSync, writeFileSync, statSync, existsSync } from 'node:fs';
 import { join, relative } from 'node:path';
+import { injectHeroLcpImagePreload } from './lcp-image-preload.mjs';
 
 /** @param {string} name */
 export function isBundledStylesheetName(name) {
@@ -46,11 +51,18 @@ export function walkHtmlFiles(dir) {
  * @returns {{ html: string, changed: boolean }}
  */
 export function injectStylesheetPreload(html, href) {
-  const marker = `href="${href}"`;
+  const marker = `rel="preload" as="style" href="${href}"`;
   if (html.includes(marker)) return { html, changed: false };
 
   const linkTag = `<link rel="preload" as="style" href="${href}" crossorigin>`;
   if (!/<head[^>]*>/i.test(html)) return { html, changed: false };
+
+  // Prefer immediately after an early LCP image preload when present.
+  const afterLcp = html.replace(
+    /(<head[^>]*>\s*<link\b[^>]*\bas=["']image["'][^>]*>)/i,
+    `$1${linkTag}`,
+  );
+  if (afterLcp !== html) return { html: afterLcp, changed: true };
 
   return {
     html: html.replace(/<head[^>]*>/i, (open) => `${open}${linkTag}`),
@@ -60,7 +72,7 @@ export function injectStylesheetPreload(html, href) {
 
 /**
  * @param {string} publicDir
- * @returns {{ href: string, updated: number }}
+ * @returns {{ href: string, updated: number, lcpUpdated: number }}
  */
 export function injectEntryCssLinkIntoPublicDir(publicDir) {
   const nuxtDir = join(publicDir, '_nuxt');
@@ -71,16 +83,19 @@ export function injectEntryCssLinkIntoPublicDir(publicDir) {
 
   const href = `/_nuxt/${cssFile}`;
   let updated = 0;
+  let lcpUpdated = 0;
 
   for (const file of walkHtmlFiles(publicDir)) {
     const before = readFileSync(file, 'utf8');
-    const { html, changed } = injectStylesheetPreload(before, href);
-    if (!changed) continue;
-    writeFileSync(file, html, 'utf8');
-    updated += 1;
+    const lcp = injectHeroLcpImagePreload(before);
+    const css = injectStylesheetPreload(lcp.html, href);
+    if (!lcp.changed && !css.changed) continue;
+    writeFileSync(file, css.html, 'utf8');
+    if (lcp.changed) lcpUpdated += 1;
+    if (css.changed) updated += 1;
   }
 
-  return { href, updated };
+  return { href, updated, lcpUpdated };
 }
 
 export { relative };

--- a/scripts/lib/lcp-image-preload.mjs
+++ b/scripts/lib/lcp-image-preload.mjs
@@ -1,0 +1,53 @@
+/**
+ * Hero LCP image preload — keep attrs in sync with NuxtImg in HeroSection.vue
+ * (sizes / densitites / format / quality) and app.vue useHead.
+ *
+ * PSI mobile (Moto G Power): 224 CSS px × ~2.625 DPR → prefers 448w.
+ * Early <head> injection cuts resource load delay (preload must not sit after
+ * ~200KB of inline CSS).
+ */
+
+export const HERO_LCP_IMAGE_HREF = '/_ipx/f_webp&q_85&fit_cover&s_448x560/img/me.jpg';
+
+/** Matches NuxtImg sizes="224px sm:256px lg:392px xl:448px" expanded form. */
+export const HERO_LCP_IMAGE_SIZES =
+  '(max-width: 640px) 224px, (max-width: 1024px) 256px, (max-width: 1280px) 392px, 448px';
+
+export const HERO_LCP_IMAGE_SRCSET = [
+  '/_ipx/f_webp&q_85&fit_cover&s_224x280/img/me.jpg 224w',
+  '/_ipx/f_webp&q_85&fit_cover&s_256x320/img/me.jpg 256w',
+  '/_ipx/f_webp&q_85&fit_cover&s_392x490/img/me.jpg 392w',
+  '/_ipx/f_webp&q_85&fit_cover&s_448x560/img/me.jpg 448w',
+].join(', ');
+
+/** @returns {string} */
+export function buildHeroLcpPreloadTag() {
+  return (
+    `<link rel="preload" as="image" type="image/webp" href="${HERO_LCP_IMAGE_HREF}"` +
+    ` fetchpriority="high" imagesizes="${HERO_LCP_IMAGE_SIZES}"` +
+    ` imagesrcset="${HERO_LCP_IMAGE_SRCSET}">`
+  );
+}
+
+/**
+ * Drop any existing hero image preload (any attribute order).
+ * @param {string} html
+ */
+export function stripHeroLcpImagePreloads(html) {
+  return html.replace(/<link\b(?=[^>]*\bas=(["'])image\1)(?=[^>]*me\.jpg)[^>]*>/gi, '');
+}
+
+/**
+ * Place the LCP image preload immediately after <head> so discovery is not
+ * blocked by theme-init + inlined CSS.
+ * @param {string} html
+ * @returns {{ html: string, changed: boolean }}
+ */
+export function injectHeroLcpImagePreload(html) {
+  if (!/<head[^>]*>/i.test(html)) return { html, changed: false };
+
+  const stripped = stripHeroLcpImagePreloads(html);
+  const tag = buildHeroLcpPreloadTag();
+  const next = stripped.replace(/<head[^>]*>/i, (open) => `${open}${tag}`);
+  return { html: next, changed: next !== html };
+}

--- a/tests/e2e/asset-integrity.spec.ts
+++ b/tests/e2e/asset-integrity.spec.ts
@@ -59,6 +59,11 @@ test.describe('SSG asset integrity', () => {
       expect(entryIdx, `${path} missing entry module`).toBeGreaterThan(-1);
       expect(preloadIdx, `${path} preload must precede entry module`).toBeLessThan(entryIdx);
 
+      // LCP image preload must precede CSS preload (cuts resource load delay).
+      const lcpIdx = html.search(/rel="preload"[^>]*as="image"|as="image"[^>]*rel="preload"/i);
+      expect(lcpIdx, `${path} missing LCP image preload`).toBeGreaterThan(-1);
+      expect(lcpIdx).toBeLessThan(preloadIdx);
+
       const css = await request.get(cssHref);
       expect(css.ok(), cssHref).toBeTruthy();
       expect(css.headers()['content-type'] || '').toMatch(/css/);

--- a/tests/e2e/generate-artifacts.spec.ts
+++ b/tests/e2e/generate-artifacts.spec.ts
@@ -26,13 +26,23 @@ test.describe('generate artifacts', () => {
 
     const html = readFileSync(indexPath, 'utf8');
     expect(html).toMatch(/rel="preload"[^>]*as="style"/);
+    // LCP image preload must be discoverable before theme-init / inlined CSS.
+    const headOpen = html.search(/<head[^>]*>/i);
+    const lcpPreload = html.search(
+      /rel="preload"[^>]*as="image"[^>]*me\.jpg|as="image"[^>]*rel="preload"[^>]*me\.jpg/i,
+    );
+    const themeInit = html.indexOf('theme-init');
+    expect(lcpPreload).toBeGreaterThan(headOpen);
+    expect(lcpPreload).toBeLessThan(themeInit);
+    expect(html).toMatch(/s_448x560\/img\/me\.jpg/);
     // Webfonts must stay off the discovery/preload critical path (LCP is the hero image).
     expect(html).not.toMatch(/rel="preload"[^>]*as="font"/);
     expect(html).toMatch(/font-display:optional/);
     expect(html).not.toContain('font-display:swap');
     // First-paint --font-main uses metric-adjusted locals only (no "Fira Code",… webfont head).
-    expect(html).toMatch(/--font-main:"Fira Code Fallback:/);
-    expect(html).not.toMatch(/--font-main:"Fira Code",/);
+    // Minified CSS may use double quotes and drop spaces after `:`.
+    expect(html).toMatch(/--font-main:\s*["']Fira Code Fallback: Consolas["']/);
+    expect(html).not.toMatch(/--font-main:\s*["']Fira Code["']/);
     expect(html).toContain('requestIdleCallback');
     expect(html).toContain('dataset.webfonts');
   });

--- a/tests/e2e/portfolio.spec.ts
+++ b/tests/e2e/portfolio.spec.ts
@@ -78,6 +78,10 @@ test.describe('portfolio SSG under CSP', () => {
     expect(res.ok()).toBeTruthy();
     const html = await res.text();
     expect(html).toMatch(/rel="preload"[^>]*as="style"[^>]*href="\/_nuxt\/[^"]+\.css"/);
+    const lcpIdx = html.search(/rel="preload"[^>]*as="image"|as="image"[^>]*rel="preload"/i);
+    const cssIdx = html.search(/rel="preload"[^>]*as="style"/i);
+    expect(lcpIdx).toBeGreaterThan(-1);
+    expect(lcpIdx).toBeLessThan(cssIdx);
     expect(html).toMatch(/__NUXT__|#__NUXT_DATA__/);
   });
 

--- a/tests/unit/deploy-invariants.spec.ts
+++ b/tests/unit/deploy-invariants.spec.ts
@@ -59,7 +59,8 @@ describe('deploy / layout invariants (regression guards)', () => {
     const init = read('app/utils/themeInitScript.ts');
     const css = read('app/assets/css/main.css');
     expect(presets).toContain('FONT_STACKS_LOCAL');
-    expect(presets).toContain('Fira Code Fallback: Segoe UI');
+    expect(presets).toContain('Fira Code Fallback: Consolas');
+    expect(presets).toContain('ui-monospace, monospace');
     expect(presets).toContain('"Fira Code", ${FONT_STACKS_LOCAL[\'Fira Code\']}');
     // Blocking theme-init applies local stack first, then load+idle activates webfonts.
     expect(init).toContain('FONT_STACKS_LOCAL');
@@ -67,8 +68,12 @@ describe('deploy / layout invariants (regression guards)', () => {
     expect(init).toContain('dataset.webfonts');
     expect(init).toContain("addEventListener('load'");
     // CSS :root must not put "Fira Code" in the used --font-main (unused webfont vars OK).
-    expect(css).toMatch(/--font-main:\s*'Fira Code Fallback:/);
+    expect(css).toMatch(/--font-main:\s*'Fira Code Fallback: Consolas'/);
     expect(css).not.toMatch(/--font-main:\s*'Fira Code'/);
+    // Mono fallbacks for Fira — proportional locals CLS the hero name on activation.
+    expect(read('nuxt.config.ts')).toMatch(
+      /name:\s*'Fira Code'[\s\S]*?fallbacks:\s*\[\s*'Consolas'/,
+    );
   });
 
   it('keeps cssCodeSplit false so CSS preload can target one stylesheet', () => {

--- a/tests/unit/entry-css-link.spec.ts
+++ b/tests/unit/entry-css-link.spec.ts
@@ -8,6 +8,10 @@ import {
   injectStylesheetPreload,
   isBundledStylesheetName,
 } from '../../scripts/lib/entry-css-link.mjs';
+import {
+  buildHeroLcpPreloadTag,
+  injectHeroLcpImagePreload,
+} from '../../scripts/lib/lcp-image-preload.mjs';
 
 describe('entry CSS preload helpers', () => {
   const dirs: string[] = [];
@@ -33,6 +37,25 @@ describe('entry CSS preload helpers', () => {
     expect(second.html.match(/rel="preload" as="style"/g)?.length).toBe(1);
   });
 
+  it('places LCP image preload before CSS preload right after <head>', () => {
+    const href = '/_nuxt/style.test.css';
+    const late =
+      '<html><head><style>.x{}</style>' +
+      '<link rel="preload" as="image" type="image/webp" href="/_ipx/f_webp&q_85&fit_cover&s_392x490/img/me.jpg" fetchpriority="high">' +
+      '</head></html>';
+    const lcp = injectHeroLcpImagePreload(late);
+    const css = injectStylesheetPreload(lcp.html, href);
+    const headInner = css.html.match(/<head[^>]*>([\s\S]*?)<\/head>/i)?.[1] ?? '';
+    const imageIdx = headInner.indexOf('as="image"');
+    const styleIdx = headInner.indexOf('as="style"');
+    const styleBlockIdx = headInner.indexOf('<style');
+    expect(imageIdx).toBeGreaterThanOrEqual(0);
+    expect(styleIdx).toBeGreaterThan(imageIdx);
+    expect(imageIdx).toBeLessThan(styleBlockIdx);
+    expect(headInner).toContain(buildHeroLcpPreloadTag());
+    expect(headInner.match(/as="image"/g)?.length).toBe(1);
+  });
+
   it('does not invent a head when missing (bad path)', () => {
     const result = injectStylesheetPreload('<html><body></body></html>', '/_nuxt/style.x.css');
     expect(result.changed).toBe(false);
@@ -52,14 +75,19 @@ describe('entry CSS preload helpers', () => {
 
     expect(findBundledStylesheet(nuxtDir)).toBe('style.abc123.css');
 
-    const { href, updated } = injectEntryCssLinkIntoPublicDir(publicDir);
+    const { href, updated, lcpUpdated } = injectEntryCssLinkIntoPublicDir(publicDir);
     expect(href).toBe('/_nuxt/style.abc123.css');
     expect(updated).toBe(2);
-    expect(readFileSync(join(publicDir, 'index.html'), 'utf8')).toContain(href);
+    expect(lcpUpdated).toBe(2);
+    const indexHtml = readFileSync(join(publicDir, 'index.html'), 'utf8');
+    expect(indexHtml).toContain(href);
+    expect(indexHtml).toContain('me.jpg');
+    expect(indexHtml.indexOf('as="image"')).toBeLessThan(indexHtml.indexOf('as="style"'));
     expect(readFileSync(join(publicDir, 'es', 'index.html'), 'utf8')).toContain(href);
 
     const again = injectEntryCssLinkIntoPublicDir(publicDir);
     expect(again.updated).toBe(0);
+    expect(again.lcpUpdated).toBe(0);
   });
 
   it('throws when no bundled CSS exists (bad path)', () => {

--- a/tests/unit/themePresets.spec.ts
+++ b/tests/unit/themePresets.spec.ts
@@ -24,7 +24,7 @@ describe('themePresets', () => {
 
   it('applies local font stacks before webfont activation in theme-init', () => {
     const script = buildThemeInitScript();
-    expect(script).toContain('Fira Code Fallback: Segoe UI');
+    expect(script).toContain('Fira Code Fallback: Consolas');
     expect(script).toContain('requestIdleCallback');
     expect(script).toContain("dataset.webfonts='1'");
     // First --font-main write must use the local map (lf), not the webfont map (f).


### PR DESCRIPTION
## Summary
- **LCP resource load delay:** inject the hero `/_ipx` image preload at the start of `<head>` (before CSS / theme-init / ~200KB inline styles), align `imagesizes`/`imagesrcset` with NuxtImg, and prefer the PSI mobile 448w candidate
- **Identical links (a11y):** unique footer social `aria-label`s via i18n (`footer.socialLinkedIn|GitHub|Email`) in en + es
- **CLS ~0.047:** switch Fira Code metric fallbacks from proportional sans to monospace (Consolas/Monaco/Menlo/Courier New) so deferred webfont activation after PR #7 does not shift the hero name
- **DOM size:** drop nested `animate-ping` span in the hero HUD status dot (easy win only)

## Test plan
- [x] `pnpm test:unit` (71 passed)
- [x] `pnpm generate:netlify` + Playwright `generate-artifacts` / `asset-integrity`
- [x] Pre-push: lint, format, typecheck, coverage
- [ ] PSI mobile on preview/prod: confirm LCP image preload is first in `<head>` and resource load delay drops
- [ ] Confirm footer social icons announce distinct names (LinkedIn / GitHub / Email)
- [ ] Spot-check hero name CLS after idle webfont activation (default GitHub Dark theme)
