### PR TITLE
fix: hash Nuxt import maps in CSP script-src

### DIFF
--- a/scripts/lib/csp.mjs
+++ b/scripts/lib/csp.mjs
@@ -5,8 +5,9 @@
  * [[headers]] are not present in that publish tree.
  *
  * After generate, write-csp-headers.mjs hashes executable inline `<script>` bodies
- * so we can drop script-src 'unsafe-inline' while keeping Nuxt SSG payloads,
- * then emits Cache-Control rules via `buildCacheHeaderBlocks()`.
+ * (including `type=importmap`) so we can drop script-src 'unsafe-inline' while
+ * keeping Nuxt SSG payloads and Vite entry maps, then emits Cache-Control rules
+ * via `buildCacheHeaderBlocks()`.
  */
 
 import { createHash } from 'node:crypto';
@@ -36,7 +37,9 @@ function* walkHtmlFiles(dir) {
 }
 
 /**
- * Executable inline scripts only (skip JSON / importmap payloads).
+ * Inline script bodies that need script-src hashes under strict CSP.
+ * Skips JSON / ld+json payloads. Includes `type=importmap` — Chromium treats
+ * import maps as script-src gated (Nuxt 4.5+/Vite 8 emit `#entry` maps).
  * @param {string} html
  * @returns {string[]}
  */
@@ -51,12 +54,7 @@ export function extractExecutableInlineScripts(html) {
     if (!body.trim()) continue;
     const typeMatch = attrs.match(/\btype\s*=\s*["']([^"']+)["']/i);
     const type = typeMatch?.[1]?.trim().toLowerCase() ?? 'text/javascript';
-    if (
-      type === 'application/json' ||
-      type === 'importmap' ||
-      type === 'application/ld+json' ||
-      type.endsWith('+json')
-    ) {
+    if (type === 'application/json' || type === 'application/ld+json' || type.endsWith('+json')) {
       continue;
     }
     bodies.push(body);

--- a/tests/unit/csp.spec.ts
+++ b/tests/unit/csp.spec.ts
@@ -30,14 +30,15 @@ describe('CSP builders', () => {
     expect(directives).toContain('trusted-types vue default');
   });
 
-  it('hashes only executable inline scripts (skips JSON / src scripts)', () => {
+  it('hashes executable inline scripts and import maps (skips JSON / src)', () => {
     const html = `
       <script src="/a.js"></script>
       <script type="application/json">{"x":1}</script>
+      <script type="importmap">{"imports":{"#entry":"/_nuxt/x.js"}}</script>
       <script>window.__NUXT__={}</script>
     `;
     const bodies = extractExecutableInlineScripts(html);
-    expect(bodies).toEqual(['window.__NUXT__={}']);
+    expect(bodies).toEqual(['{"imports":{"#entry":"/_nuxt/x.js"}}', 'window.__NUXT__={}']);
     expect(hashInlineScript(bodies[0]!)).toMatch(/^'sha256-[A-Za-z0-9+/=]+'$/);
   });
 


### PR DESCRIPTION
## Summary
- Nuxt 4.5 / Vite 8 emit `<script type=importmap>` for `#entry`.
- Chromium enforces `script-src` on import maps; our CSP hasher skipped them, so e2e CSP checks failed after #14.
- Include importmap bodies in `extractExecutableInlineScripts` and update unit coverage.

## Test plan
- [x] `pnpm vitest run tests/unit/csp.spec.ts`
- [x] `playwright test tests/e2e/portfolio.spec.ts` (local)
- [ ] CI validate / e2e green