### PR TITLE
fix: make case-study CTAs distinguishable for a11y

### DIFF
--- a/app/components/CaseStudiesSection.vue
+++ b/app/components/CaseStudiesSection.vue
@@ -118,6 +118,11 @@ function studyTags(slug: (typeof studies)[number]['slug']): string[] {
 
               <NuxtLink
                 :to="localePath(study.to)"
+                :aria-label="
+                  $t('caseStudies.readMoreAria', {
+                    title: $t(`caseStudies.items.${study.slug}.cardTitle`),
+                  })
+                "
                 class="btn-premium bg-primary text-primary-contrast rounded-2xl px-6 py-3 border-none w-fit inline-flex items-center gap-2 font-black uppercase tracking-widest"
               >
                 {{ $t('caseStudies.readMore') }}

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -706,6 +706,7 @@
     "lead": "Selected product work with verifiable scope — frontend architecture, design systems, and AI-assisted craft in production ed-tech.",
     "tagsLabel": "Technologies and focus areas",
     "readMore": "Read case study",
+    "readMoreAria": "Read case study: {title}",
     "items": {
       "colegium": {
         "role": "Senior Frontend · Colegium",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -706,6 +706,7 @@
     "lead": "Trabajo de producto con alcance verificable: arquitectura frontend, design systems y craft asistido por IA en ed-tech de producción.",
     "tagsLabel": "Tecnologías y áreas de enfoque",
     "readMore": "Leer caso de estudio",
+    "readMoreAria": "Leer caso de estudio: {title}",
     "items": {
       "colegium": {
         "role": "Senior Frontend · Colegium",

--- a/tests/e2e/hero-conversion.spec.ts
+++ b/tests/e2e/hero-conversion.spec.ts
@@ -58,4 +58,20 @@ test.describe('hero conversion hierarchy', () => {
     const nameText = (await hero.locator('h1').innerText()).replace(/\s+/g, ' ');
     expect(nameText).toMatch(/César\s+Gómez|Cesar\s+Gomez|CESAR\s+GOMEZ/i);
   });
+
+  test('case-study CTAs include their destination in the accessible name', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+
+    const caseStudies = page.locator('#case-studies');
+    await expect(
+      caseStudies.getByRole('link', {
+        name: /Read case study: Cloud platforms for 100k\+ students/i,
+      }),
+    ).toBeVisible();
+    await expect(
+      caseStudies.getByRole('link', {
+        name: /Read case study: Speech-first language learning product/i,
+      }),
+    ).toBeVisible();
+  });
 });

--- a/tests/unit/case-studies-i18n.spec.ts
+++ b/tests/unit/case-studies-i18n.spec.ts
@@ -33,6 +33,7 @@ function assertCaseStudiesContract(messages: LocaleMessages, locale: string) {
     'caseStudies.lead',
     'caseStudies.tagsLabel',
     'caseStudies.readMore',
+    'caseStudies.readMoreAria',
   ] as const;
 
   for (const key of topLevelKeys) {


### PR DESCRIPTION
## Summary
- Homepage Colegium / LingoQuesto CTAs keep the same visible copy (`Read case study`) but now expose unique accessible names via `caseStudies.readMoreAria`.
- Adds EN/ES i18n keys plus unit + Playwright coverage for the axe identical-links audit.

## Test plan
- [x] `pnpm vitest run tests/unit/case-studies-i18n.spec.ts`
- [x] `pnpm exec playwright test tests/e2e/hero-conversion.spec.ts tests/e2e/interactive-a11y.spec.ts`
- [ ] CI validate / Netlify preview