### PR TITLE
fix: restore icon client bundle and harden service worker

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -193,10 +193,9 @@ export default defineNuxtConfig({
     provider: 'none',
     fallbackToApi: false,
     serverBundle: 'local',
-    // CSS mode — no Iconify client SVG payload. Keep scan off to avoid unused JS.
+    // Scan templates (incl. Lazy islands) so icons ship offline — empty scan broke prod icons.
     clientBundle: {
-      scan: false,
-      icons: [],
+      scan: true,
     },
   },
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'cesar-gomez-portfolio-v6';
+const CACHE_NAME = 'cesar-gomez-portfolio-v7';
 const IS_LOCALHOST = ['localhost', '127.0.0.1', '[::1]'].includes(self.location.hostname);
 const urlsToCache = [
   '/img/logo-final.svg?v=cg2',
@@ -10,6 +10,17 @@ const urlsToCache = [
 const isNavigationRequest = (request) =>
   request.mode === 'navigate' ||
   (request.method === 'GET' && request.headers.get('accept')?.includes('text/html'));
+
+/** Only http(s) GET — skip chrome-extension:, blob:, etc. (Cache.put rejects those schemes). */
+const isCacheableRequest = (request) => {
+  if (request.method !== 'GET') return false;
+  try {
+    const { protocol } = new URL(request.url);
+    return protocol === 'http:' || protocol === 'https:';
+  } catch {
+    return false;
+  }
+};
 
 /** Brand marks / favicons must not stick on stale cache-first entries after deploys. */
 const isBrandAsset = (url) => {
@@ -30,6 +41,17 @@ const isBrandAsset = (url) => {
   }
 };
 
+const matchOrNetworkError = (request) =>
+  caches.match(request).then((cached) => cached || Response.error());
+
+const putInCache = (request, response) => {
+  if (!isCacheableRequest(request)) return;
+  const copy = response.clone();
+  void caches.open(CACHE_NAME).then((cache) => cache.put(request, copy)).catch(() => {
+    // Ignore quota / scheme errors — never reject the fetch handler.
+  });
+};
+
 // Install event - cache static assets only (not HTML — hashes change each deploy)
 self.addEventListener('install', (event) => {
   if (IS_LOCALHOST) {
@@ -44,6 +66,8 @@ self.addEventListener('install', (event) => {
 // Fetch event - network-first for pages + brand assets; cache-first for other static
 self.addEventListener('fetch', (event) => {
   if (IS_LOCALHOST) return;
+  // Let the browser handle non-http(s) / non-GET (extensions, WebSocket upgrades, etc.).
+  if (!isCacheableRequest(event.request)) return;
 
   if (isNavigationRequest(event.request)) {
     event.respondWith(fetch(event.request));
@@ -55,12 +79,11 @@ self.addEventListener('fetch', (event) => {
       fetch(event.request)
         .then((response) => {
           if (response && response.status === 200 && response.type === 'basic') {
-            const copy = response.clone();
-            caches.open(CACHE_NAME).then((cache) => cache.put(event.request, copy));
+            putInCache(event.request, response);
           }
           return response;
         })
-        .catch(() => caches.match(event.request)),
+        .catch(() => matchOrNetworkError(event.request)),
     );
     return;
   }
@@ -71,23 +94,20 @@ self.addEventListener('fetch', (event) => {
         return response;
       }
 
-      const fetchRequest = event.request.clone();
-
-      return fetch(fetchRequest)
-        .then((response) => {
-          if (!response || response.status !== 200 || response.type !== 'basic') {
-            return response;
+      return fetch(event.request.clone())
+        .then((networkResponse) => {
+          if (
+            !networkResponse ||
+            networkResponse.status !== 200 ||
+            networkResponse.type !== 'basic'
+          ) {
+            return networkResponse;
           }
 
-          const responseToCache = response.clone();
-
-          caches.open(CACHE_NAME).then((cache) => {
-            cache.put(event.request, responseToCache);
-          });
-
-          return response;
+          putInCache(event.request, networkResponse);
+          return networkResponse;
         })
-        .catch(() => caches.match(event.request));
+        .catch(() => matchOrNetworkError(event.request));
     }),
   );
 });

--- a/quality/BASELINE.md
+++ b/quality/BASELINE.md
@@ -27,7 +27,7 @@ Report: [uyky82oqhc](https://pagespeed.web.dev/analysis/https-cesargomez-dev/uyk
 - Hero `sizes`/preload aligned to CSS display (~154px mobile → prefer 392w) — cuts image-delivery + LCP load-delay.
 - `/_ipx/*` Cache-Control → immutable 1y; `/img/*` → 30d + SWR.
 - Accessible names: CONTACT / Vibe Coding include visible text (Label in Name).
-- Deferred navbar/about/tech/particles hydration; disabled card tilt on coarse pointers; Nuxt Icon CSS mode with `clientBundle.scan: false` (no Iconify SVG client payload).
+- Deferred navbar/about/tech/particles hydration; disabled card tilt on coarse pointers; Nuxt Icon CSS mode with `clientBundle.scan: true` (provider none — icons must ship in the client bundle).
 
 ### Documented residuals (not code-blocking)
 

--- a/tests/unit/nuxt-icon-config.spec.ts
+++ b/tests/unit/nuxt-icon-config.spec.ts
@@ -9,8 +9,7 @@ describe('nuxt icon config', () => {
     expect(config).toMatch(/provider:\s*'none'/);
     expect(config).toMatch(/fallbackToApi:\s*false/);
     expect(config).toMatch(/clientBundle:\s*\{/);
-    expect(config).toMatch(/scan:\s*false/);
-    expect(config).toMatch(/icons:\s*\[\s*\]/);
-    expect(config).not.toMatch(/scan:\s*true/);
+    expect(config).toMatch(/scan:\s*true/);
+    expect(config).not.toMatch(/scan:\s*false/);
   });
 });

--- a/tests/unit/sw.spec.ts
+++ b/tests/unit/sw.spec.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('public/sw.js', () => {
+  const source = readFileSync(join(process.cwd(), 'public/sw.js'), 'utf8');
+
+  it('skips non-http(s) requests so Cache.put never sees chrome-extension', () => {
+    expect(source).toMatch(/isCacheableRequest/);
+    expect(source).toMatch(/protocol === 'http:' \|\| protocol === 'https:'/);
+    expect(source).toMatch(/if \(!isCacheableRequest\(event\.request\)\) return/);
+  });
+
+  it('never resolves respondWith with undefined when cache misses', () => {
+    expect(source).toMatch(/matchOrNetworkError/);
+    expect(source).toMatch(/cached \|\| Response\.error\(\)/);
+    expect(source).not.toMatch(/\.catch\(\(\) => caches\.match\(event\.request\)\)/);
+  });
+
+  it('bumps CACHE_NAME when fetch/caching semantics change', () => {
+    expect(source).toMatch(/cesar-gomez-portfolio-v7/);
+  });
+});


### PR DESCRIPTION
## Summary
- Production icons were blank after `clientBundle.scan: false` with `provider: 'none'` — restore template scan so icons ship offline under CSP.
- Harden `public/sw.js`: ignore `chrome-extension:` (and other non-http schemes), always return a `Response` on cache miss, bump cache to `v7`.

## Test plan
- [x] `pnpm vitest run tests/unit/nuxt-icon-config.spec.ts tests/unit/sw.spec.ts`
- [x] lint + typecheck
- [ ] After deploy: hard refresh / unregister old SW; confirm icons paint and console has no Cache.put / Response errors